### PR TITLE
fix code snippet in add-custom-snaps

### DIFF
--- a/docs/how-to-guides/image-creation/add-custom-snaps.md
+++ b/docs/how-to-guides/image-creation/add-custom-snaps.md
@@ -11,7 +11,7 @@ ubuntu-image snap ubuntu-core-20-amd64.model
 
 _ubuntu-image_ tool retrieves signed snaps with the given _snap-id_ in the model assertion from the store. To override these default snaps, first make sure the [model assertion](/t/model-assertion/19745#heading--fields) has a grade of dangerous to allow non-store snaps to be included:
 
-```json
+```
 grade: dangerous
 ```
 


### PR DESCRIPTION
This tiny change should fix `grade: dangerous` snippet formatting.

![image](https://github.com/user-attachments/assets/12ab4107-fbf0-4c39-a24a-678c1e013842)
