### PR TITLE
fix ubuntu core header link

### DIFF
--- a/docs/.sphinx/_templates/header.html
+++ b/docs/.sphinx/_templates/header.html
@@ -5,7 +5,7 @@
     <ul class="p-navigation__links" role="menu">
 
       <li>
-        <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
+        <a class="p-logo" href="{{ product_page }}" aria-current="page">
           <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
           <div class="p-logo-text p-heading--4">{{ project }}
           </div>
@@ -13,7 +13,7 @@
       </li>
 
       <li class="nav-ubuntu-com">
-        <a href="https://{{ product_page }}" class="p-navigation__link">{{ product_page }}</a>
+        <a href="{{ product_page }}" class="p-navigation__link">{{ product_page }}</a>
       </li>
 
       <li>


### PR DESCRIPTION
This fixes the header links from showing as `https://https//ubuntu.com/core`