### PR TITLE
UC docs are now migrated from discourse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,9 @@
 Ubuntu Core documentation
 =========================
 
-Ubuntu Core documentation can currently be found here:
+This repository contains the source files to build the Ubuntu Core documentation, which is published here:
+
 https://ubuntu.com/core/docs
-
-The above documentation is published directly from Discourse:
-https://discourse.ubuntu.com/c/ubuntu-core-docs/47
-
-**November, 2024: Work in progress**
-
-This repository contains the source files to build the Ubuntu Core documentation outside of Discourse. We are actively working to migrate the source material to this repository. 
 
 The documentation is written in Markdown and built with Sphinx, all taken from the `Documentation starter pack`_.
 


### PR DESCRIPTION
Simplify the wording in the README, now that the master copy of the docs has migrated to the GH repository.