### PR TITLE
Fix whitespace and indentation

### DIFF
--- a/docs/explanation/system-snaps/modem-manager/1
+++ b/docs/explanation/system-snaps/modem-manager/1
@@ -52,8 +52,8 @@ nmap <leader>di <Plug>ToggleDitto      " Turn Ditto on and off
 
 " If you don't want the autocmds, you can also use an operator to check
 " specific parts of your text:
-" vmap <leader>d <Plug>Ditto	       " Call Ditto on visual selection
-" nmap <leader>d <Plug>Ditto	       " Call Ditto on operator movement
+" vmap <leader>d <Plug>Ditto          " Call Ditto on visual selection
+" nmap <leader>d <Plug>Ditto          " Call Ditto on operator movement
 
 nmap =d <Plug>DittoNext                " Jump to the next word
 nmap -d <Plug>DittoPrev                " Jump to the previous word

--- a/docs/reference/assertions/repair.md
+++ b/docs/reference/assertions/repair.md
@@ -57,7 +57,7 @@ devices will be targeted.
 
 The following is an example repair assertion used by the testing suite at Canonical:
 
-```json	
+```json
 {
   "headers": {
     "architectures": [

--- a/docs/reference/assertions/store.md
+++ b/docs/reference/assertions/store.md
@@ -5,16 +5,16 @@ The store assertion defines the configuration needed to connect a device to a st
 
 ```yaml
 type: store
-authority-id:	   <authority account id>
-store:			   <store name>
+authority-id:      <authority account id>
+store:             <store name>
 friendly-stores:   <list of trusted store names> # Their snaps will be made available to the store.
-operator-id: 	   <account id>
-url: 			   <optional api url>
-location: 		   <optional location string>
-timestamp:		   <UTC datetime>
-sign-key-sha3-384: <key id> # Encoded key id of signing key
+operator-id:       <account id>
+url:               <optional api url>
+location:          <optional location string>
+timestamp:         <UTC datetime>
+sign-key-sha3-384: <key id>                      # Encoded key id of signing key
 
-<signature>                 # Encoded signature
+<signature>                                      # Encoded signature
 ```
 
 The following is a complete example store assertion:

--- a/docs/reference/gadget-snap-format.md
+++ b/docs/reference/gadget-snap-format.md
@@ -45,7 +45,7 @@ In the near future, we expect to add a RISC-V reference gadget snap to this list
 
 Two YAML keys are used to describe your target device:
 
-- **defaults** (YAML sub-section, optional): default configuration options for the defined snaps, applied on installation:	
+- **defaults** (YAML sub-section, optional): default configuration options for the defined snaps, applied on installation:
    ```yaml
    defaults:
          <snap id>:
@@ -231,16 +231,16 @@ volumes:
         # The offset from the beginning of the image. Defaults to right after
         # prior structure item. (optional)
         offset: <bytes> | <bytes/2^20>M | <bytes/2^30>G
-	
-	# OffsetWrite describes a 32-bit address within the volume at which the
-	# offset of the current structure will be written. When this feature was
-	# first implemented, the position could be specified as a byte-offset
-	# relative to the start of any named structure in the volume. However,
-	# its scope has now been limited to only accept a structure with an
-	# offset of 0, which implies the offset will always be absolute. This
-	# should not cause any issues as the only known use case for this is to
-	# set an address in an MBR. Writes outside of the first structure
-	# now also blocked.
+
+        # OffsetWrite describes a 32-bit address within the volume at which the
+        # offset of the current structure will be written. When this feature was
+        # first implemented, the position could be specified as a byte-offset
+        # relative to the start of any named structure in the volume. However,
+        # its scope has now been limited to only accept a structure with an
+        # offset of 0, which implies the offset will always be absolute. This
+        # should not cause any issues as the only known use case for this is to
+        # set an address in an MBR. Writes outside of the first structure
+        # now also blocked.
         # (optional)
         offset-write: [<name>+]<bytes> |
                       [<name>+]<bytes/2^20>M |


### PR DESCRIPTION
Fixes some indentation and some weird formatting around tabs:
![image](https://github.com/user-attachments/assets/5132c8ff-d62b-40f3-97c7-73f5cd4c5a28)

There's also a similar issue with JSON/YAML bits that aren't strictly correct (like assertions that enumerate options for a field `foo: bar|baz`) but this doesn't solve that