### PR TITLE
Add ephemeral section and improve field descriptions

### DIFF
--- a/docs/reference/assertions/confdb-schema.md
+++ b/docs/reference/assertions/confdb-schema.md
@@ -292,3 +292,20 @@ Type definitions can also take the form of a list of alternative types. When val
   }
 }
 ```
+
+### Ephemeral Data
+Paths to ephemeral data can be marked as such with a `ephemeral: true` field. This is supported by any schema type and does not apply any constraint to the data itself. It is only used by snapd to know whether a custodian might want to store it externally.
+
+```
+{
+  "schema": {
+    "name": "string",
+    "version": {
+      "type": "string",
+      "ephemeral": true
+    }
+  }
+}
+```
+
+The `ephemeral` field defaults to `false`, if omitted.

--- a/docs/reference/assertions/confdb-schema.md
+++ b/docs/reference/assertions/confdb-schema.md
@@ -49,10 +49,10 @@ sign-key-sha3-384:  <key id>                # Encoded key id of signing key
 
 The `views` header can have any number of views, each with a fine-grained set of rules and access controls tailored to a specific use case. Each view must contain a `rules` list with each rule describing how a particular configuration can be accessed from outside the system and where snapd should store and retrieve it:
 
-- **`storage`** (*required*)
-    A dotted path to a stored JSON value. Must not be prohibited by the storage schema declared in the body.
 - **`request`** (*optional*)
-    A dotted path describing how the snap or admin can access the value. If omitted, defaults to the storage path.
+    A dotted path describing how the configuration can be accessed. If omitted, defaults to the storage path. May contain placeholder path parts wrapped in curly brackets (see example) which match any request value. The placeholder value is mapped to an equally named placeholder in the storage path.
+- **`storage`** (*required*)
+    A dotted path to a stored JSON value. Must not be prohibited by the storage schema declared in the body. May contain placeholder path parts matching the ones in the request path.
 - **`access`** (*optional*)
     Access control for the given rule. Can be read-only, write-only or read-write. If omitted, defaults to read-write.
 - **`content`** (*optional*)


### PR DESCRIPTION
770c2809153ac416c9fae4622b1c3708cecf9d5c adds an ephemeral data section exemplifying how to mark data as ephemeral
c47313bb5e0a0304d59c3710ef3d99fc5bd9d391 mentions placeholders in request/storage fields and generally improves them a bit