### PR TITLE
rename container to match the right ubuntu codename

### DIFF
--- a/docs/how-to-guides/image-creation/build-a-kernel-snap.md
+++ b/docs/how-to-guides/image-creation/build-a-kernel-snap.md
@@ -525,7 +525,7 @@ Unlike broader snap packages, kernel snaps are typically built within the host e
 ```bash
 sudo snap install lxd
 sudo lxd init --auto
-sudo lxc launch ubuntu:22.04 focal
+sudo lxc launch ubuntu:22.04 jammy
 sudo lxc shell focal
 snap install snapcraft --classic
 ```


### PR DESCRIPTION
- Fixes: https://github.com/canonical/ubuntu-core-docs/issues/214