### PR TITLE
How-to section on including assertions in built images

### DIFF
--- a/docs/how-to-guides/image-creation/use-ubuntu-image.md
+++ b/docs/how-to-guides/image-creation/use-ubuntu-image.md
@@ -96,6 +96,12 @@ These additional snaps can include [custom snaps](/how-to-guides/image-creation/
 - Production-grade images cannot include custom snaps, and additional snaps must first be declared with a `presence` attribute of `optional` in the model.
 - **Offline snaps** must include locally cached assertions. Using offline locally stored snaps can speed up the image creation process.
 
+## Extra assertions
+
+Arbitrary assertions, such as [system-user assertions](/reference/assertions/system-user/), can be included in the final image using the '--assertion' argument pointing to a file containing one or more assertions. This can help you, for example, in creating a system user or choosing a snap store proxy without the added manual configuration after the installation is complete.
+
+It is possible to add assertions of any kind except for `snap-declaration`, `snap-revision`, `model`, `serial` and `validation-set`.
+
 ## Image size
 
 The size of a generated disk image can optionally be controlled with the `--image-size` argument.


### PR DESCRIPTION
Add a short section in the how-to guide for using `ubuntu-image` to include arbitrary assertions in images at build time.
The section includes a small suggestion on what the flag might be useful for.

Please give feedback if the option is not relevant enough and/or out of scope for this documentation page.