### PR TITLE
Multiple fixes

### DIFF
--- a/docs/how-to-guides/image-creation/board-enablement.md
+++ b/docs/how-to-guides/image-creation/board-enablement.md
@@ -217,7 +217,7 @@ snap known --remote model series=16 brand-id=canonical model=pi3
 
 ## Image building
 
-Images are built from a model assertion using [ubuntu-image](https://github.com/CanonicalLtd/ubuntu-image), a tool to generate a bootable image. It can be installed on a [snap-supporting Linux system](https://snapcraft.io/docs/installing-snapd) as follows:
+Images are built from a model assertion using [ubuntu-image](https://github.com/canonical/ubuntu-image), a tool to generate a bootable image. It can be installed on a [snap-supporting Linux system](https://snapcraft.io/docs/installing-snapd) as follows:
 
 ```bash
 snap install ubuntu-image --classic
@@ -226,17 +226,16 @@ snap install ubuntu-image --classic
 You can now build your image using the following command:
 
 ```bash
-sudo ubuntu-image \
+ubuntu-image \
 -c stable \        # available channels are: edge/beta/candidate/stable
 --image-size 4G \
---extra-snaps <gadget snap file name, e.g. roseapple-pi_16.04-1_armhf.snap> \
---extra-snaps <kernel snap file name, e.g. roseapple-pi-kernel_3.10.37-1_armhf.snap> \
---extra-snaps <add more preinstalled snaps here, names from the store or local paths> \
--o <image output file name, e.g. roseapple-pi-20161107-0.img> \
+--snap <gadget snap file name, e.g. roseapple-pi_16.04-1_armhf.snap> \
+--snap <kernel snap file name, e.g. roseapple-pi-kernel_3.10.37-1_armhf.snap> \
+--snap <add more preinstalled snaps here, names from the store or local paths> \
 <model file name, e.g. roseapple.model>
 ```
 
-Note: The `--extra-snaps` argument takes either a snap name accessible from the store or a local path to a built snap.
+Note: The `--snap` argument takes either a snap name accessible from the store or a local path to a built snap.
 
 Your image is ready, you can use a tool like `dd` to write the image to an SD Card and boot your board.
 
@@ -251,12 +250,11 @@ curl -H "Accept: application/x.ubuntu.assertion" "https://assertions.ubuntu.com/
 ```
 
 ```bash
-sudo ubuntu-image \
+ubuntu-image \
 -c stable \
 --image-size 4G \
---extra-snaps pi2-kernel \
---extra-snaps pi3 \
---extra-snaps nextcloud \
--o pi3-20161107-0.img \
+--snap pi2-kernel \
+--snap pi3 \
+--snap nextcloud \
 pi3.model
 ```

--- a/docs/how-to-guides/image-creation/use-ubuntu-image.md
+++ b/docs/how-to-guides/image-creation/use-ubuntu-image.md
@@ -88,7 +88,7 @@ The output includes the _img_ file itself, alongside a _seed.manifest_ file. The
 
 ## Additional snaps
 
-Snaps can be optionally added at build time with the '--snap' argument.
+Snaps can be optionally added at build time with the `--snap` argument.
 
 These additional snaps can include [custom snaps](/how-to-guides/image-creation/add-custom-snaps), locally-stored [offline snaps](/explanation/remodelling.md#offline-remodelling), and snaps that can be downloaded directly from the store.
 
@@ -102,9 +102,9 @@ The size of a generated disk image can optionally be controlled with the `--imag
 
 The value is the size in bytes, with allowable suffixes M for MiB and G for GiB and if this size is smaller than the minimum calculated size of the volume, a warning is issued and the option is ignored.
 
-An extended syntax is supported for [Gadget snaps](/how-to-guides/image-creation/build-a-gadget-snap) that specify multiple volumes (i.e. disk images). In that case, a single SIZE argument is used for all the defined volumes, with the same rules for ignoring values that are too small. You can specify the image size for a single volume using an indexing prefix on the SIZE parameter, where the index is either a volume name or an integer index starting at zero. For example, to set the image size only on the second volume, which might be called sdcard in gadget.yaml, use: --image-size 1:8G (the number 1 index indicates the second volume; volumes are 0-indexed). Or use --image-size sdcard:8G.
+An extended syntax is supported for [Gadget snaps](/how-to-guides/image-creation/build-a-gadget-snap) that specify multiple volumes (i.e. disk images). In that case, a single SIZE argument is used for all the defined volumes, with the same rules for ignoring values that are too small. You can specify the image size for a single volume using an indexing prefix on the SIZE parameter, where the index is either a volume name or an integer index starting at zero. For example, to set the image size only on the second volume, which might be called sdcard in gadget.yaml, use: `--image-size 1:8G` (the number 1 index indicates the second volume; volumes are 0-indexed). Or use `--image-size sdcard:8G`.
 
-You can also specify multiple volume sizes by separating them with commas, and you can mix and match integer indices and volume-name indices. Thus, if gadget.yaml names three volumes, and you want to set all three to different sizes, you can use --image-size 0:2G,sdcard:8G,eMMC:4G.
+You can also specify multiple volume sizes by separating them with commas, and you can mix and match integer indices and volume-name indices. Thus, if gadget.yaml names three volumes, and you want to set all three to different sizes, you can use `--image-size 0:2G,sdcard:8G,eMMC:4G`.
 
 ## Testing an image
 
@@ -120,7 +120,7 @@ ssh <username>@localhost -p 8022
 
 You are now connected to the Ubuntu Core virtual machine, from where you can configure and install whatever apps you need. 
 
-To list which snaps are installed, for example, type 'snap list' and to view the model assertion used to build the image, type `snap model --assertion`:
+To list which snaps are installed, for example, type `snap list` and to view the model assertion used to build the image, type `snap model --assertion`:
 
 ```bash
 $ snap model --assertion


### PR DESCRIPTION
- fix deprecated arguments on `ubuntu-image` command and remove useless `sudo`
https://github.com/canonical/ubuntu-image/blob/main/debian/changelog#L439
https://github.com/canonical/ubuntu-image/blob/main/debian/changelog#L267

- fix some links

- fix style