### PR TITLE
fix: update rpi-imager and general improvements

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,7 +111,7 @@ We welcome contributions, suggestions, fixes and constructive feedback from the 
 
 Contributing to our documentation is straightforward. We only require that all contributors sign the [Canonical contributor license agreement](https://ubuntu.com/legal/contributors).
 
-In order to contribute, you will need to set up a [GitHub](https://github.com/) account and a git environment. The [Get started with git](https://canonical-coda.readthedocs-hosted.com/en/latest/docs/howto/get-started/using_git/) guide, from the Canonical Open Documentation Academy, is a useful resource for people who are new to contributing using the Ubuntu command line.
+In order to contribute, you will need to set up a [GitHub](https://github.com/) account and a git environment. The [Get started with git](https://documentationacademy.org/docs/howto/get-started/using_git/) guide, from the Canonical Open Documentation Academy, is a useful resource for people who are new to contributing using the Ubuntu command line.
 
 The navigational structure, style, and content of our documentation follows the Diátaxis systematic framework for technical documentation. This categorizes the documentation into tutorials, how-to guides, reference material and explanatory text.
 

--- a/docs/explanation/system-snaps/network-manager/how-to-guides/networkmanager-and-netplan.md
+++ b/docs/explanation/system-snaps/network-manager/how-to-guides/networkmanager-and-netplan.md
@@ -16,9 +16,9 @@ Note that only devices explicitly configured within Netplan configuration files,
 
 From _core20_ onwards, network-manager been modified to use a YAML backend that's based on _libnetplan_ functionality.
 
-The YAML backend replaces the keyfile format used by Network Manager with `/etc/Netplan/*.yaml`.
+The YAML backend replaces the keyfile format used by Network Manager with `/etc/netplan/*.yaml`.
 
-The default configuration, for example, can be output by running the `cat sudo cat /etc/netplan/00-snapd-config.yaml` to produce show following output:
+The default configuration, for example, can be output by running the `sudo cat /etc/netplan/00-snapd-config.yaml` to produce show following output:
 
 ```yaml
 # This is the network config written by 'console-conf'
@@ -29,9 +29,9 @@ network:
   version: 2
 ```
 
-On boot the Netplan.io generator processes all of the YAML files and renders them into the corresponding a Network Manager configuration in `/run/NetworkManager/system-connections`. The usual `Netplan generate/try/apply` can be used to re-generate this configuration after the YAML was modified.
+On boot the netplan.io generator processes all of the YAML files and renders them into the corresponding a Network Manager configuration in `/run/NetworkManager/system-connections`. The usual `netplan generate/try/apply` can be used to re-generate this configuration after the YAML was modified.
 
-If a connection profile is modified or created from within Network Manager, such as updating a Wi-Fi password with `nmcli`, Network Manager will create an ephemeral keyfile that will be immediately converted to Netplan YAML and stored in `/etc/Netplan`. Network Manager automatically calls `Netplan generate` to re-process the current YAML configuration to render Network Manager connection profiles in `/run/NetworkManager/system-connections`.
+If a connection profile is modified or created from within Network Manager, such as updating a Wi-Fi password with `nmcli`, Network Manager will create an ephemeral keyfile that will be immediately converted to Netplan YAML and stored in `/etc/netplan`. Network Manager automatically calls `netplan generate` to re-process the current YAML configuration to render Network Manager connection profiles in `/run/NetworkManager/system-connections`.
 
 The system wide network configuration can be read with `sudo netplan get`:
 

--- a/docs/tutorials/try-pre-built-images/install-on-a-device/install-on-renesas.md
+++ b/docs/tutorials/try-pre-built-images/install-on-a-device/install-on-renesas.md
@@ -114,14 +114,15 @@ Download and install Raspberry Pi Imager from one of the following locations:
 
 After it's installed and running, you will see its main window showing buttons for the three step download and write process:
 
-![Raspberry Pi Imager](https://assets.ubuntu.com/v1/7f4829d7-7f4829d76af46a7e658117b72cba3bc04611c798.jpeg)
+![Raspberry Pi Imager](https://assets.ubuntu.com/v1/617104fd-raspberry-pi-imager.png)
 
-1. Select **Choose OS** and a pop-up list appears. Scroll down to the bottom and select **Use custom**.  In the file requester that appears, select the `ubuntu-core24-rzg2l.img.xz` image file you just downloaded. The _xz_ file can be selected without being decompressed first.
+1. Select **Choose Device** and a Raspberry Pi devices list appears. Now select "No filtering" from the list.
 
+2. Select **Choose OS** and a pop-up list appears. Scroll down to the bottom and select **Use custom**.  In the file requester that appears, select the `ubuntu-core24-rzg2l.img.xz` image file you just downloaded. The _xz_ file can be selected without being decompressed first.
 
-2. Select **Choose Storage** and insert your microSD if you haven't already. Now select the device from the list.
+3. Select **Choose Storage** and insert your microSD if you haven't already. Now select the device from the list.
 
-3. Finally, select **Write**. A warning will state that all data on your selected device will be erased, so it's worth double checking your selection was correct. Select **Yes** if you're sure. You may then be asked for your password before the download, write and verification processes begin.
+4. Finally, select **Next**. A warning will state that all data on your selected device will be erased, so it's worth double checking your selection was correct. Select **Yes** if you're sure. You may then be asked for your password before the download, write and verification processes begin.
 
 When the process has finished, Raspberry Pi Imager will proclaim "Write Successful" and you can remove the card from the reader. It's now ready to be inserted into your device.
 

--- a/docs/tutorials/try-pre-built-images/install-on-a-device/use-raspberry-pi-imager.md
+++ b/docs/tutorials/try-pre-built-images/install-on-a-device/use-raspberry-pi-imager.md
@@ -42,15 +42,17 @@ Download and install Raspberry Pi Imager from one of the following locations:
 
 After it's installed and running, you will see its main window showing buttons for the three step download and write process:
 
-![Raspberry Pi Imager](https://assets.ubuntu.com/v1/7f4829d7-7f4829d76af46a7e658117b72cba3bc04611c798.jpeg)
+![Raspberry Pi Imager](https://assets.ubuntu.com/v1/617104fd-raspberry-pi-imager.png)
 
-1. Select **Choose OS** and a pop-up list appears. Scroll down and select **Other general-purpose OS** followed by **Ubuntu**. Now scroll to the bottom of the Ubuntu list and select **Ubuntu Core 24 (64-bit)**. 
+1. Select **Choose Device** and a Raspberry Pi devices list appears. Now select your Raspberry Pi device from the list.
+
+2. Select **Choose OS** and a pop-up list appears. Scroll down and select **Other general-purpose OS** followed by **Ubuntu**. Now scroll to the bottom of the Ubuntu list and select **Ubuntu Core 24 (64-bit)**. 
 
    You can alternatively download the image manually ([ubuntu-core-24-arm64+raspi.img.xz](https://cdimage.ubuntu.com/ubuntu-core/24/stable/current/ubuntu-core-24-arm64+raspi.img.xz)) and instead choose **Use custom** from bottom of the **Choose OS** menu. In the file requester that appears, select the image you just downloaded. The _xz_ file can be selected without being decompressed first.
 
-2. Select **Choose Storage** and insert your microSD if you haven't already. Now select the device from the list.
+3. Select **Choose Storage** and insert your microSD if you haven't already. Now select the device from the list.
 
-3. Finally, select **Write**. A warning will state that all data on your selected device will be erased, so it's worth double checking your selection was correct. Select **Yes** if you're sure. You may then be asked for your password before the download, write and verification processes begin.
+4. Finally, select **Next**. A warning will state that all data on your selected device will be erased, so it's worth double checking your selection was correct. Select **Yes** if you're sure. You may then be asked for your password before the download, write and verification processes begin.
 
 When the process has finished, Raspberry Pi Imager will proclaim "Write Successful" and you can remove the card from the reader. It's now ready to be inserted into your Raspberry Pi.
 


### PR DESCRIPTION
- Fix incorrect link
- Folder `/etc/Netplan` replaced by `/etc/netplan`, and replace `Netplan` binary calls by `netplan`
- [DRAFT] Update rpi-imager instructions based on newer version of the tool
**please make sure to update the rpi-imager screenshot with this one** (could not upload it to https://assets.ubuntu.com, don't have access to yet)

![Screenshot From 2025-06-19 11-19-03](https://github.com/user-attachments/assets/1916ecde-d337-46c2-aa3b-562f467707a7)