### PR TITLE
build-your-first-image: Fix "Sign the model" hyperlink

### DIFF
--- a/docs/tutorials/build-your-first-image/index.md
+++ b/docs/tutorials/build-your-first-image/index.md
@@ -73,7 +73,7 @@ Learn how to sign a model with a GPG key to make it into a _model assertion_.
 
   Upload the key and register it with your Ubuntu One account by using `register-key` command. After creating the key, update the timestamp in `my-model.json`.
 
-* [Sign the model](sign-the-model.md#sign-the-model)
+* [Sign the model](sign-the-model.md#id1)
 
   Use the `snap sign` command to update the JSON file with the key name.
 


### PR DESCRIPTION
I noticed in [Build your first image](https://documentation.ubuntu.com/core/tutorials/build-your-first-image/index.html) the ["Sign the model" hyperlink](https://documentation.ubuntu.com/core/tutorials/build-your-first-image/sign-the-model/#sign-the-model) does not actually go to the appropriate section; it goes to the top.

That is because the page *and* section are both named "Sign the model":

```
1 # Sign the model
[...]
69 ## Sign the model
```

I'm not sure how this can be fixed properly. For now, I'm making it hyperlink to ["id1"](https://documentation.ubuntu.com/core/tutorials/build-your-first-image/sign-the-model/#id1) as I see on my browser.