### PR TITLE
Fix system-boot partition size calculation

### DIFF
--- a/docs/how-to-guides/image-creation/calculate-partition-sizes.md
+++ b/docs/how-to-guides/image-creation/calculate-partition-sizes.md
@@ -24,7 +24,7 @@ The recommended sizes for each partition type and role are as follows:
 
   For example, the size of kernel.efi is around 52 MiBs. If we take a [refresh.retain=3](https://snapcraft.io/docs/managing-updates#control-updates-with-system-options-5) (the default for Ubuntu Core, and for classic/hybrid it is 2) and 10 MiBs for additional boot components, such as grub and u-boot, this would give a minimum size of around:
 
-  52*4 + 10 = 418 MiBs
+  52*4 + 10 = 218 MiBs
 
 - Here, the multiplication of the kernel.efi by 4 is due to the requirement of 3 snap files due to the specified refresh.retain, plus 1 for a temporary file while doing a refresh.
 

--- a/docs/how-to-guides/image-creation/calculate-partition-sizes.md
+++ b/docs/how-to-guides/image-creation/calculate-partition-sizes.md
@@ -26,7 +26,7 @@ The recommended sizes for each partition type and role are as follows:
 
   52*4 + 10 = 218 MiBs
 
-- Here, the multiplication of the kernel.efi by 4 is due to the requirement of 3 snap files due to the specified refresh.retain, plus 1 for a temporary file while doing a refresh.
+  Here, the multiplication of the kernel.efi by 4 is due to the requirement of 3 snap files due to the specified refresh.retain, plus 1 for a temporary file while doing a refresh.
 
    Therefore the minimum system-boot required is:
 


### PR DESCRIPTION
This PR updates the calculation for the system-boot partition size to reflect the correct minimum required space.

`52*4 + 10 = 418 MiBs`  => `52*4 + 10 = 218 MiBs`

<details><summary>Details</summary>

### Before
<img width="1283" height="767" alt="image" src="https://github.com/user-attachments/assets/e106667d-2a25-429f-aa87-97f050e27705" />

### After
<img width="829" height="508" alt="image" src="https://github.com/user-attachments/assets/503a158c-5244-4b54-918b-62303344fa3f" />

</details> 

