### PR TITLE
Update architecture and disclaimer for Maintenance customers

### DIFF
--- a/docs/reference/support-duration.md
+++ b/docs/reference/support-duration.md
@@ -14,8 +14,8 @@ A Legacy add-on can be optionally purchased to cover an additional 5 years of se
 | Ubuntu Core 22 | Jun 2022 | Jun 2032 | Jun 2037 | amd64, arm64 | - |
 | Ubuntu Core 24 | Jun 2024 | Jun 2034 | Jun 2039 | amd64, arm64, armhf | - |
 
+* For additional information applicable to customers under a Maintenance Agreement, please contact your designated Sales Director.
+
 ```{note}
 Supported Ubuntu Core components include the snap daemon (SnapD), the [kernel snap](https://ubuntu.com/kernel/lifecycle) and the [base](https://documentation.ubuntu.com/snapcraft/stable/reference/bases/#base-snap-reference) for each respective release. See [Inside Ubuntu Core](/explanation/core-elements/inside-ubuntu-core) for details on how Ubuntu Core is composed, and the [Ubuntu Pro service description](https://canonical.com/legal/ubuntu-pro#ubuntu-pro-service-description) for Pro support coverage.
-
-* For additional information applicable to customers under a Maintenance Agreement, please contact your designated Sales Director.
 ```


### PR DESCRIPTION
Officially, armhf legacy support is only available for Core 24  however, customer X (armhf and core 16) - can get legacy support since they are an enablement + maintenance customer