### PR TITLE
Add UC26 landing page and update release notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,8 @@ Thinking about using Ubuntu Core for your next project? [Get in touch](https://u
 ```{toctree}
 :hidden:
 :maxdepth: 2
+
+Latest: Ubuntu Core 26 <uc26>
 ```
 
 ```{toctree}

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -11,7 +11,7 @@ This page outlines the release notes of Ubuntu Core, summarising new features, b
 
 ## Latest stable release
 
-* **{ref}`Ubuntu Core 26 <ref-release-notes_ubuntu-core-26-release-notes>`** (12th May 2026)
+* **{ref}`Ubuntu Core 26 <ref-release-notes_ubuntu-core-26-release-notes>`** (14th May 2026)
 
 ## Older releases
 
@@ -56,7 +56,7 @@ To ensure you receive latest security updates and bug fixes, ensure you upgrade 
 (ref-release-notes_ubuntu-core-26-release-notes)=
 ## Ubuntu Core 26 release notes
 
-Released: 12th May 2026.
+Released: 14th May 2026.
 
 Ubuntu Core 26 (UC26) is the latest Ubuntu Core release, and is built on the foundations of [Ubuntu 26.04 LTS (Resolute Raccoon)](https://releases.ubuntu.com/26.04/).
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -11,7 +11,7 @@ This page outlines the release notes of Ubuntu Core, summarising new features, b
 
 ## Latest stable release
 
-* **{ref}`Ubuntu Core 26 <ref-release-notes_ubuntu-core-26-release-notes>`** (7th May 2026)
+* **{ref}`Ubuntu Core 26 <ref-release-notes_ubuntu-core-26-release-notes>`** (12th May 2026)
 
 ## Older releases
 
@@ -56,7 +56,7 @@ To ensure you receive latest security updates and bug fixes, ensure you upgrade 
 (ref-release-notes_ubuntu-core-26-release-notes)=
 ## Ubuntu Core 26 release notes
 
-Released: 7th May 2026.
+Released: 12th May 2026.
 
 Ubuntu Core 26 (UC26) is the latest Ubuntu Core release, and is built on the foundations of [Ubuntu 26.04 LTS (Resolute Raccoon)](https://releases.ubuntu.com/26.04/).
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -11,10 +11,11 @@ This page outlines the release notes of Ubuntu Core, summarising new features, b
 
 ## Latest stable release
 
-* **{ref}`Ubuntu Core 24 <ref-release-notes_ubuntu-core-24-release-notes>`** (4th June 2024)
+* **{ref}`Ubuntu Core 26 <ref-release-notes_ubuntu-core-26-release-notes>`** (7th May 2026)
 
 ## Older releases
 
+* **{ref}`Ubuntu Core 24 <ref-release-notes_ubuntu-core-24-release-notes>`** (4th June 2024)
 * **{ref}`Ubuntu Core 22 <ref-release-notes_ubuntu-core-22-release-notes>`** (15th June 2022)
 
 (ref-release-notes_release-policy-and-schedule)=
@@ -51,6 +52,63 @@ To upgrade an Ubuntu Core image from one version to another, see {ref}`Upgrade U
 The snap daemon, snapd, manages snap package updates and Ubuntu Core functionality. For the snapd release plan and a complete list of changes, please refer to the [snapd roadmap](https://snapcraft.io/docs/snapd-roadmap). Feel free to provide your test feedback on the [forum](https://forum.snapcraft.io/c/snapd/5), or directly in [Launchpad](https://bugs.launchpad.net/snapd/+filebug).
 
 To ensure you receive latest security updates and bug fixes, ensure you upgrade to a new release of snapd shortly after it is released.
+
+(ref-release-notes_ubuntu-core-26-release-notes)=
+## Ubuntu Core 26 release notes
+
+Released: 7th May 2026.
+
+Ubuntu Core 26 (UC26) is the latest Ubuntu Core release, and is built on the foundations of [Ubuntu 26.04 LTS (Resolute Raccoon)](https://releases.ubuntu.com/26.04/).
+
+With up to 15 years of security maintenance, our strictly-confined OS enables developers to {ref}`build <ref-index-build-your-first-image>` and {ref}`deploy <ref-index_how-to-deploy-an-image>` production-grade images for embedded devices on various architectures.
+
+Ubuntu Core 26 includes system-level improvements in boot performance, OTA update sizes (reduced by up to 90%), and image composition through Chisel.
+
+New features for this release include:
+
+* Boot and update time improvements
+* Chisel-based build system for minimal images
+* CRA (Coordinated Remediation and Assurance) compliance support
+* Livepatch support for kernel patching
+* Components general availability
+* Enhanced API documentation with automatic endpoint discovery
+* Python removal from core base snaps (improved security and reduced image size)
+
+For complete details, see the {ref}`dedicated Ubuntu Core 26 release notes <ref-uc26>`.
+
+(release-notes-cloud-init)=
+### Bundled Python changes for Ubuntu Core 26
+
+Core base snaps (e.g. core22, core24) provide a run-time environment with a minimal set of libraries that are common to many applications.
+
+Core base snaps up to and including core24 bundle the Python interpreter alongside a selection of Python libraries. But from core26 onwards, Python packages will no longer be included. This change does not affect earlier core base snaps.
+
+The majority of application snaps that need Python already stage Python independently. These snaps will not need to be modified.
+
+If your snap relies on the Python interpreter provided by the core snap, and you are switching or planning to use the new core26 base and later versions, you will need to add the Python plugin to your snap.
+
+### Why are we making this change?
+
+We continuously simplify core base snaps to remove unnecessary dependencies, improve maintainability, reduce attack surface, and keep the runtime environment minimal and predictable. In this context, core bases historically shipped some Python dependencies.
+
+However, the recommended approach for snap creators has always been to use the [Python plugin](https://documentation.ubuntu.com/snapcraft/stable/how-to/integrations/craft-a-python-app/) and bundle their own Python runtime inside their application snaps, including only the packages and dependencies they require. As a result, the Python interpreter and libraries provided by core snaps are often unused.
+
+For this reason, starting with **core26**, the Python environment in the core base snap won't be available at runtime.
+
+This change better reflects how snaps are built and used today, where snap developers retain full control over their Python versions and dependencies. It also allows for the core base to be simplified. Over time, this will also allow for a reduction in the overall size of the core snaps.
+
+### How to manage the Python environment in your snap
+
+Developers publishing snaps with Python-based parts can continue to use the **Snapcraft Python plugin**, which allows you to bundle the exact Python version and dependencies your application requires. Detailed guidance is available in the How-to Guide
+[Craft a Python app ](https://documentation.ubuntu.com/snapcraft/stable/how-to/integrations/craft-a-python-app/)
+
+For projects that use Poetry or uv, developers should consider using the separate Snapcraft plugins built for these dependency management tools. A full list of available plugins and their usage is available in the [Plugin Reference](https://documentation.ubuntu.com/snapcraft/stable/reference/plugins/).
+
+### Impact on cloud-init
+
+This change does **not** affect cloud-init usage, which will remain present and fully supported in this release.
+
+However, since not every user requires cloud-init, a new track will be available for **core26**. This track will include cloud-init and the Python environment it needs.
 
 (ref-release-notes_ubuntu-core-24-release-notes)=
 ## Ubuntu Core 24 release notes

--- a/docs/reference/software-bill-of-materials.md
+++ b/docs/reference/software-bill-of-materials.md
@@ -7,6 +7,7 @@ SBOMs are required under the EU Cyber Resilience Act and referenced by the US NT
 
 SBOMs for each Ubuntu Core release are available from the following links:
 
+- Ubuntu Core 26 SBOM (under review, pending release)
 - [Ubuntu Core 24 SBOM](sboms/core24_1587.spdx2.3.json)
 - [Ubuntu Core 22 SBOM](sboms/core22_2411.spdx2.3.json)
 - [Ubuntu Core 20 SBOM](sboms/core20_2769.spdx2.3.json)

--- a/docs/uc26.md
+++ b/docs/uc26.md
@@ -1,7 +1,7 @@
 (ref-uc26)=
 # Ubuntu Core 26
 
-*Released: 12th May 2026*
+*Released: 14th May 2026*
 
 Ubuntu Core 26 (UC26) is the latest Ubuntu Core release, and is built on the foundations of [Ubuntu 26.04 LTS (Resolute Raccoon)](https://canonical.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon).
 

--- a/docs/uc26.md
+++ b/docs/uc26.md
@@ -7,22 +7,16 @@ Ubuntu Core 26 (UC26) is the latest Ubuntu Core release, and is built on the fou
 
 With up to 15 years of security maintenance, Ubuntu Core is a minimal, immutable OS that enables developers to {ref}`build <ref-index-build-your-first-image>` and {ref}`deploy <ref-index_how-to-deploy-an-image>` production-grade images for embedded devices on various architectures at any scale.
 
-Ubuntu Core 26 includes system-level improvements in boot performance, OTA update sizes (reduced by up to 90%), and image composition through [Chisel](https://documentation.ubuntu.com/chisel/latest/).
+Ubuntu Core 26 includes system-level improvements in update performance, OTA update sizes (reduced by up to 90%), and image composition through [Chisel](https://documentation.ubuntu.com/chisel/latest/).
 
 Key updates in this release include:
 
-* Boot and update time improvements
 * Chisel-based build system
+* Update time improvements
 * CRA compliance
 * Livepatch support
 * Components general availability
 * New API documentation
-
-## Improved boot and update time
-
-An updated snap-delta format reduces update sizes by 50% to 90% for most snaps.
-
-Updates to core base snaps decrease from 16MB to 1.5MB. These changes are paired with boot optimizations and initramfs-based installation paths that avoid redundant reboots by default.
 
 ## Now built with Chisel
 
@@ -31,6 +25,12 @@ Ubuntu Core 26 uses a [Chisel-based](https://documentation.ubuntu.com/chisel/lat
 Every file in the filesystem can now be attributed to its originating slice and source package, improving the accuracy of integrity checks and vulnerability triage.
 
 The new build system also contributes to a 7% reduction in base image size.
+
+## Improved update time
+
+An updated snap-delta format reduces update sizes for most snaps.
+
+Updates to core base snaps decrease from 16MB to 1.5MB. These changes are paired with boot optimizations and initramfs-based installation paths that avoid redundant reboots by default.
 
 ## CRA compliance
 

--- a/docs/uc26.md
+++ b/docs/uc26.md
@@ -1,7 +1,7 @@
 (ref-uc26)=
 # Ubuntu Core 26
 
-*Released: 7th May 2026*
+*Released: 12th May 2026*
 
 Ubuntu Core 26 (UC26) is the latest Ubuntu Core release, and is built on the foundations of [Ubuntu 26.04 LTS (Resolute Raccoon)](https://canonical.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon).
 

--- a/docs/uc26.md
+++ b/docs/uc26.md
@@ -1,0 +1,72 @@
+(ref-uc26)=
+# Ubuntu Core 26
+
+*Released: 7th May 2026*
+
+Ubuntu Core 26 (UC26) is the latest Ubuntu Core release, and is built on the foundations of [Ubuntu 26.04 LTS (Resolute Raccoon)](https://canonical.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon).
+
+With up to 15 years of security maintenance, Ubuntu Core is a minimal, immutable OS that enables developers to {ref}`build <ref-index-build-your-first-image>` and {ref}`deploy <ref-index_how-to-deploy-an-image>` production-grade images for embedded devices on various architectures at any scale.
+
+Ubuntu Core 26 includes system-level improvements in boot performance, OTA update sizes (reduced by up to 90%), and image composition through [Chisel](https://documentation.ubuntu.com/chisel/latest/).
+
+Key updates in this release include:
+
+* Boot and update time improvements
+* Chisel-based build system
+* CRA compliance
+* Livepatch support
+* Components general availability
+* New API documentation
+
+## Improved boot and update time
+
+An updated snap-delta format reduces update sizes by 50% to 90% for most snaps.
+
+Updates to core base snaps decrease from 16MB to 1.5MB. These changes are paired with boot optimizations and initramfs-based installation paths that avoid redundant reboots by default.
+
+## Now built with Chisel
+
+Ubuntu Core 26 uses a [Chisel-based](https://documentation.ubuntu.com/chisel/latest/) build system for base snap composition. It relies on release-specific package slice definitions to enforce explicit, traceable dependencies.
+
+Every file in the filesystem can now be attributed to its originating slice and source package, improving the accuracy of integrity checks and vulnerability triage.
+
+The new build system also contributes to a 7% reduction in base image size.
+
+## CRA compliance
+
+The EU Cyber Resilience Act (CRA) requires products to be secure by default, supported over the long term, and backed by clear accountability across the software stack.
+
+Ubuntu Core addresses these requirements through secure design, software traceability, and modular architecture with well-defined responsibility boundaries.
+
+Canonical assumes Manufacturer responsibilities for the operating system release cycle by providing security maintenance for Ubuntu Core core modules, continuous CVE monitoring and coordinated disclosure, and compliance with IEC 62443-4-1.
+
+## Livepatch support
+
+Canonical [Livepatch](https://ubuntu.com/security/livepatch) is supported in Ubuntu Core 26.
+
+This means devices can now receive critical kernel security updates without a reboot, reducing disruption for always-on systems.
+
+## Fleet management
+
+For fleet observability, Ubuntu Core 26 integrates with the [Canonical Observability Stack](https://canonical.com/observability), built on Juju and Kubernetes. Ubuntu Core can stream logs and metrics from devices to centralized Grafana, Loki, and Prometheus infrastructure deployed in cloud or on-premise environments.
+
+## Components general availability
+
+First tested in Ubuntu Core 24 for delivering NVIDIA drivers, [*components*](https://documentation.ubuntu.com/snapcraft/stable/reference/components/) are now generally available. They allow snap maintainers to distribute large or optional resources, such as debug symbols, translations, or optional drivers, alongside the main snap without increasing the base installation footprint.
+
+## New API documentation
+
+The Snapd REST API is now OpenAPI compliant and includes overhauled Swagger-based documentation.
+
+This provides a machine-readable API definition that supports endpoint discovery, request and response validation, and client generation with standard OpenAPI tools. It also improves consistency between the documentation and API behavior, making automation easier to test and maintain across releases.
+
+See the [Snapd REST API reference](https://snapcraft.io/docs/reference/development/snapd-rest-api/) for details.
+
+## Further improvements
+
+This release adds many other new features, including:
+
+* Self-service interface connections through a [new system option](https://snapcraft.io/docs/reference/administration/system-options/#system-interface)
+* Cross-snap and device configuration with [ConfDB](https://snapcraft.io/docs/explanation/how-snaps-work/confdb-configuration-mechanism/)
+
+From this release onwards, the Python environment in the core base snap won’t be available at runtime. See {ref}`release-notes-cloud-init` for more details.


### PR DESCRIPTION
This pull request updates the documentation to add release notes and details for Ubuntu Core 26 (UC26), the latest version of Ubuntu Core. It introduces a new dedicated release notes section, highlights major new features and changes, and explains the removal of Python from the core base snaps. The most important changes are:

**Release Notes and Documentation Updates:**

* Added a new section to the documentation for Ubuntu Core 26, including a dedicated release notes page (`docs/uc26.md`) with details on new features such as improved boot/update times, Chisel-based builds, CRA compliance, Livepatch support, and more.
* Updated the main release notes index to include Ubuntu Core 26 as the latest stable release, and moved Ubuntu Core 24 to the "Older releases" section.
* Added a prominent link to the Ubuntu Core 26 documentation in the main documentation index.

**Key Technical and Platform Changes:**

* Documented the removal of Python from core base snaps starting with core26, including guidance for snap developers on bundling Python and the impact on cloud-init.
* Provided a summary of major UC26 improvements, including reduced OTA update sizes, Chisel-based image composition, enhanced API documentation, and new compliance features. [[1]](diffhunk://#diff-ff1b3fa9c6ac0d03e086eadfa6de816f344550eb6f230573d76ca7966854579eR1-R72) [[2]](diffhunk://#diff-bf6e34f4be5b2637ead8a69fbabda0dd25d0935e01748b10ae4c59849e2e3e45R56-R112)
