### PR TITLE
docs(ref/assertions): add confdb-control assertion

### DIFF
--- a/docs/reference/assertions/confdb-control.md
+++ b/docs/reference/assertions/confdb-control.md
@@ -44,7 +44,7 @@ sign-key-sha3-384: <key id>   # Encoded key id of signing key
 Unlike most assertion types, confdb-control has no `authority-id` header. That header normally names the account on whose authority an assertion is made, but here the device is its own authority and signs the assertion with its own device key.
 
 (reference-assertions-confdb-control-groups)=
-## Groups
+### Groups
 
 Each delegation in `groups` grants one or more operators control over a set of confdb views, limited to a specific set of allowed authentication methods.
 
@@ -65,11 +65,11 @@ Multiple methods can be listed, in which case a message signed by any of them is
 
 ### Views
 
-A list of confdb view paths, each in the form `<account-id>/<confdb-schema>/<view>`. These paths refer to views defined in {ref}`confdb-schema assertions <reference-assertions-confdb-schema>` and can span multiple schemas. The access level available to operators for each view is determined by the view's own `access` definition in the confdb-schema assertion.
+A list of confdb views, each in the form `<account-id>/<confdb-schema>/<view>`. These paths refer to views defined in {ref}`confdb-schema assertions <reference-assertions-confdb-schema>` and can span multiple schemas. The access level available to operators for each view is determined by the view's own `access` definition in the confdb-schema assertion.
 
 ## Managing delegations
 
-Any change to the assertion, whether delegating control to a new operator or revoking an existing delegation, is made through the [`POST /v2/confdb`](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/AuthenticationRequired/postConfdbControl) snapd API endpoint rather than by editing the assertion directly. Each change increments the assertion's revision, which snapd re-signs and acknowledges automatically. Modifying the assertion requires root privileges. Other users can view it but cannot change it.
+Any change to the assertion, whether delegating control to a new operator or revoking an existing delegation, is made through the [`POST /v2/confdb`](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/AuthenticationRequired/postConfdbControl) snapd API endpoint rather than by editing the assertion directly. Each change increments the assertion's revision, which snapd re-signs and acknowledges automatically. Modifying the assertion requires root privileges.
 
 The endpoint provides two actions. Delegating grants an operator control over a set of views under a chosen set of authentication methods. Undelegating withdraws an operator's control, either over specific views and authentication methods or, if none are given, entirely.
 

--- a/docs/reference/assertions/confdb-control.md
+++ b/docs/reference/assertions/confdb-control.md
@@ -48,22 +48,22 @@ Unlike most assertion types, confdb-control has no `authority-id` header. That h
 
 Each delegation in `groups` grants one or more operators control over a set of confdb views, limited to a specific set of allowed authentication methods.
 
-### Operators
+#### Operators
 
 A list of the account IDs being delegated to.
 
-### Authentications
+#### Authentications
 
 Operators manage the device by sending it signed confdb request messages, and the `authentications` field limits which keys may sign those messages on an operator's behalf. Two methods are supported:
 
 - **`operator-key`**
-    Messages must be signed with the operator's own private key.
+    Messages must be signed with the operator's own private key(s).
 - **`store`**
-    Messages may be signed on behalf of the operator by the Snap Store.
+    The operator delegates signing authority to the Snap Store, which signs messages using its own key(s).
 
 Multiple methods can be listed, in which case a message signed by any of them is accepted.
 
-### Views
+#### Views
 
 A list of confdb views, each in the form `<account-id>/<confdb-schema>/<view>`. These paths refer to views defined in {ref}`confdb-schema assertions <reference-assertions-confdb-schema>` and can span multiple schemas. The access level available to operators for each view is determined by the view's own `access` definition in the confdb-schema assertion.
 

--- a/docs/reference/assertions/confdb-control.md
+++ b/docs/reference/assertions/confdb-control.md
@@ -1,0 +1,104 @@
+---
+myst:
+  html_meta:
+    description: Confdb-control assertion reference. Delegate control of confdb views to operators.
+---
+
+(reference-assertions-confdb-control)=
+# confdb-control
+
+The confdb-control assertion grants operators control over specific subsets of a device's [confdb views](https://snapcraft.io/docs/explanation/how-snaps-work/confdb-configuration-mechanism/). Operators are accounts, typically in the Snap Store, that the device delegates this control to. The device is the authority over those views: it issues and signs the assertion itself, and holds only one at a time.
+
+The assertion follows the principle of least privilege: each operator receives precisely the access defined by the views it is granted, where the read or write access level comes from the view's own definition in its {ref}`confdb-schema assertion <reference-assertions-confdb-schema>`.
+
+## Fields
+
+The format of the confdb-control assertion is as follows:
+
+```yaml
+type:        confdb-control
+brand-id:    <brand-id>
+model:       <model>
+serial:      <serial>
+groups:
+  - operators:       [ <operator-id>, ... ]
+    authentications: [ operator-key | store | ... ]
+    views:
+      - <account-id>/<confdb-schema>/<view>
+      - ...
+  - ...
+sign-key-sha3-384: <key id>   # Encoded key id of signing key
+
+<signature>                   # Encoded device signature
+```
+
+- **`brand-id`** (*required*)
+    The account ID of the device's brand, matching the device's {ref}`model assertion <reference-assertions-model>`. Together with `model` and `serial`, forms the primary key of this assertion.
+- **`model`** (*required*)
+    The device's model name, matching its {ref}`model assertion <reference-assertions-model>`.
+- **`serial`** (*required*)
+    The unique identifier for the device within its model, matching its {ref}`serial assertion <reference-assertions-serial>`.
+- **`groups`** (*required*)
+    A list of delegations. Each delegation grants a set of operators control over a set of views through a given set of authentication methods. See {ref}`Groups <reference-assertions-confdb-control-groups>` below.
+
+Unlike most assertion types, confdb-control has no `authority-id` header. That header normally names the account on whose authority an assertion is made, but here the device is its own authority and signs the assertion with its own device key.
+
+(reference-assertions-confdb-control-groups)=
+## Groups
+
+Each delegation in `groups` grants one or more operators control over a set of confdb views, limited to a specific set of allowed authentication methods.
+
+### Operators
+
+A list of the account IDs being delegated to.
+
+### Authentications
+
+Operators manage the device by sending it signed confdb request messages, and the `authentications` field limits which keys may sign those messages on an operator's behalf. Two methods are supported:
+
+- **`operator-key`**
+    Messages must be signed with the operator's own private key.
+- **`store`**
+    Messages may be signed on behalf of the operator by the Snap Store.
+
+Multiple methods can be listed, in which case a message signed by any of them is accepted.
+
+### Views
+
+A list of confdb view paths, each in the form `<account-id>/<confdb-schema>/<view>`. These paths refer to views defined in {ref}`confdb-schema assertions <reference-assertions-confdb-schema>` and can span multiple schemas. The access level available to operators for each view is determined by the view's own `access` definition in the confdb-schema assertion.
+
+## Managing delegations
+
+Any change to the assertion, whether delegating control to a new operator or revoking an existing delegation, is made through the [`POST /v2/confdb`](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/AuthenticationRequired/postConfdbControl) snapd API endpoint rather than by editing the assertion directly. Each change increments the assertion's revision, which snapd re-signs and acknowledges automatically. Modifying the assertion requires root privileges. Other users can view it but cannot change it.
+
+The endpoint provides two actions. Delegating grants an operator control over a set of views under a chosen set of authentication methods. Undelegating withdraws an operator's control, either over specific views and authentication methods or, if none are given, entirely.
+
+## Example assertion
+
+A device's confdb-control assertion can be viewed with `sudo snap known confdb-control`. For example:
+
+```yaml
+type: confdb-control
+brand-id: acme
+model: assembly-robot
+serial: 8e8af03a-4b32-4e91-b10a-b9e5d1f0c72f
+groups:
+  - operators: [ acme-robotics ]
+    authentications: [ operator-key, store ]
+    views:
+      - acme/controls/accelerometer-admin
+      - acme/controls/accelerometer-state
+      - acme/controls/actuator-admin
+  - operators: [ acme-monitor ]
+    authentications: [ store ]
+    views:
+      - acme/controls/accelerometer-state
+  - operators: [ acme-ops ]
+    authentications: [ operator-key ]
+    views:
+      - system/network/wifi-admin
+      - system/network/wifi-state
+sign-key-sha3-384: BWDEoaqyr25nF5SNCvEv2v7QnM9QsfCc0PBMYD_i2NGSQ32EF2d4D0hqUel3m8ul
+
+AcLBUgQAAQoABgUCWCIWcgAAReg...
+```

--- a/docs/reference/assertions/index.md
+++ b/docs/reference/assertions/index.md
@@ -7,7 +7,7 @@ myst:
 (ref-index_assertions)=
 # Assertions
 
-An assertion is a digitally signed document that either verifies the validity of a process, as attested by the signer, or carries policy information, as formulated by the signer.  
+An assertion is a digitally signed document that either verifies the validity of a process, as attested by the signer, or carries policy information, as formulated by the signer.
 
 [Snapcraft](https://snapcraft.io/docs/snapcraft), [snapd](https://snapcraft.io/docs/glossary#heading--snapd), the [Snap Store](https://snapcraft.io/store) and {ref}`Brand stores <ref-dedicated-snap-store_dedicated-snap-store>` all use assertions to handle a variety of functions and processes, including authentication, policy setting, identification and validation.
 
@@ -19,6 +19,7 @@ These are the currently used assertion types:
 
 - **{ref}`account <reference-assertions-account>`**: links an account name to its identifier and other properties
 - **{ref}`account-key <reference-assertions-account-key>`**: holds the public part of a key belonging to the account
+- **{ref}`confdb-control <reference-assertions-confdb-control>`**: delegates control of confdb views to operators
 - **{ref}`confdb-schema <reference-assertions-confdb-schema>`**: describes the access rules and data schema for the configuration of a set of snaps or a facet of the system
 - **{ref}`model <reference-assertions-model>`**: brand-specified properties for the device, used to drive the building of an Ubuntu Core image
 - **{ref}`repair <reference-assertions-repair>`**: a unique assertion used to restore a device as a last resort feature
@@ -89,7 +90,7 @@ Fetching assertions for "gnome-calculator"
 Install the snap with:
    snap ack gnome-calculator_544.assert
    snap install gnome-calculator_544.snap
-$ cat gnome-calculator_544.assert 
+$ cat gnome-calculator_544.assert
 type: account-key
 authority-id: canonical
 revision: 2


### PR DESCRIPTION
Adds a reference page for the confdb-control assertion, which a device issues to delegate control over subsets of its confdb views to operators.

Specification: [SD172](https://docs.google.com/document/d/1hi133dMpUBrKmYYbLsIWY5TKxsjwTU50ssZNiOZiCCc/edit?usp=sharing)
Implementation: [snapd/asserts/confdb.go](https://github.com/canonical/snapd/blob/master/asserts/confdb.go#L115)