### PR TITLE
docs: add link to pre-built uc26 images at the uc26 landing page

### DIFF
--- a/docs/uc26.md
+++ b/docs/uc26.md
@@ -9,6 +9,8 @@ With up to 15 years of security maintenance, Ubuntu Core is a minimal, immutable
 
 Ubuntu Core 26 includes system-level improvements in update performance, OTA update sizes (reduced by up to 90%), and image composition through [Chisel](https://documentation.ubuntu.com/chisel/latest/).
 
+{ref}`Try pre-built images <ref-index_try-pre-built-images>` available at [https://cdimage.ubuntu.com/ubuntu-core/26/stable/current/](https://cdimage.ubuntu.com/ubuntu-core/26/stable/current/).
+
 Key updates in this release include:
 
 * Chisel-based build system


### PR DESCRIPTION
Fixes #357