### PR TITLE
how-to/cuda: change target from UC24+ to UC24 due to missing UC26 NVIDIA support

### DIFF
--- a/docs/how-to-guides/cuda-workloads.md
+++ b/docs/how-to-guides/cuda-workloads.md
@@ -15,17 +15,13 @@ NVIDIA GPU as the DRI device, which means that one can use integrated Intel
 graphics (or, indeed, no graphics at all) and still use the CUDA cores available
 to them.
 
-## Ubuntu Core 24+
+## Ubuntu Core 24
 
 ```{note}
 This guide requires snapd 2.67 or later, which introduced stable support for snap components. Existing devices may need to refresh snapd to enable full components support.
 ```
 
-The general implementation is similar across Core releases, using the respective
-versions of the mentioned snaps. This section will make references to Ubuntu Core
-24 specific snaps.
-
-On Ubuntu Core 24+, most of the setup for kernel drivers and libraries is already
+On Ubuntu Core 24, most of the setup for kernel drivers and libraries is already
 taken care of as part of the distribution.
 Completion of the setup is a responsibility of the device owner, who must install
 the NVIDIA kernel drivers and userspace libraries, and of the application


### PR DESCRIPTION
Currently, there is no solution for NVIDIA userspace drivers on UC26.
The page was originally created aiming for UC24+, as it was understood that the solution would be identical.
Instead, implementation is not complete and there are multiple proposed solutions.

Until support is finalized, the UC24+ language should be removed to avoid confusion to our users, which I have now done.

Should I also add a warning about UC26 support not being available for the time being to avoid any doubt?