### PR TITLE
Remove the early access warning from renesas page

### DIFF
--- a/docs/how-to-guides/deploy-an-image/install-on-renesas.md
+++ b/docs/how-to-guides/deploy-an-image/install-on-renesas.md
@@ -8,13 +8,6 @@ Ubuntu Core runs on a large range of hardware, and pre-built images are availabl
 
 Renesas RZ/G2L installation is accomplished in two stages; with the first stage preparing the board and installing the bootloader, and the second stage installing the Ubuntu Core image.
 
-```{admonition} Early access for Renesas RZ/G2L
- :class: warning
-
-Ubuntu Core images for Renesas RZ/G2L devices are currently at an _early access_ stage, and should not be considered appropriate for production deployment.
-
-Work is underway to build Ubuntu Core production images for these boards.
-```
 ## Requirements
 
 In addition to having a basic understanding of Linux, including running commands from the terminal, you will need the following:


### PR DESCRIPTION
G2L has been cerified, no EA warning needed anymore