### PR TITLE
docs: fix full disk encryption hook links

### DIFF
--- a/docs/explanation/full-disk-encryption-op-tee.md
+++ b/docs/explanation/full-disk-encryption-op-tee.md
@@ -13,7 +13,7 @@ OP-TEE is an open source Trusted Execution Environment (TEE) for Arm systems. It
 
 Snapd (the snap daemon) integrates with a Canonical-provided [OP-TEE TA](https://github.com/canonical/optee-uc-fde) that knows how to seal and unseal LUKS keys inside the secure world.
 
-During installation, snapd decides how to seal the LUKS disk keys. It first looks for a kernel [`fde-setup` hook](https://snapcraft.io/docs/uc20-fde-hooks#heading--fde-setup), then for the dedicated OP-TEE TA, and finally falls back to TPM-backed sealing. The selection is automatic and requires no user input.
+During installation, snapd decides how to seal the LUKS disk keys. It first looks for a kernel [`fde-setup` hook](https://forum.snapcraft.io/t/uc20-uc22-full-disk-encryption-hook-interface/24439#heading--fde-setup), then for the dedicated OP-TEE TA, and finally falls back to TPM-backed sealing. The selection is automatic and requires no user input.
 
 When OP-TEE is selected, snapd asks the TA to seal the disk key. The TA performs the encryption inside the secure world and hands back the sealed key. The encrypted key is stored on disk so that it can be used to decrypt the LUKS partition later. Note that only the TA can decrypt the sealed key, so storing the sealed key is safe.
 

--- a/docs/explanation/full-disk-encryption.md
+++ b/docs/explanation/full-disk-encryption.md
@@ -22,7 +22,7 @@ The following factors affect how a device is encrypted:
 - {ref}`Disabling encryption <ref-full-disk-encryption_disabling-encryption>`: an optional parameter that can disable encryption
 - {ref}`Model grade <ref-full-disk-encryption_model-grade>`: interacts with _storage-safety_ to set the device constraints 
 
-For a non-standard (non-UEFI+TPM platform) FDE platform, such as a Raspberry Pi or other ARM devices, implementation is board-specific and will typically involve creating custom gadget and kernel snaps. UC20/UC22, however, do provide a helper mechanism, via a hook interface, to ensure the integrity of any subsequently executed or accessed data. See the [full-disk-encryption hook interface](https://snapcraft.io/docs/uc20-fde-hooks) for further details.
+For a non-standard (non-UEFI+TPM platform) FDE platform, such as a Raspberry Pi or other ARM devices, implementation is board-specific and will typically involve creating custom gadget and kernel snaps. UC20/UC22, however, do provide a helper mechanism, via a hook interface, to ensure the integrity of any subsequently executed or accessed data. See the [full-disk-encryption hook interface](https://forum.snapcraft.io/t/uc20-uc22-full-disk-encryption-hook-interface/24439) for further details.
 
 (ref-full-disk-encryption_storage-layouts)=
 ## Storage layouts


### PR DESCRIPTION
## Summary

Fixes the stale full-disk-encryption hook interface links reported in #381.

The previous `https://snapcraft.io/docs/uc20-fde-hooks` URL now redirects to a 404. This updates both Ubuntu Core docs references to the live Snapcraft Forum FDE hook interface page, preserving the `#heading--fde-setup` anchor where the OP-TEE page links directly to `fde-setup`.

## Verification

- `curl -L -I --max-time 20 https://snapcraft.io/docs/uc20-fde-hooks` (reproduced HTTP 404 before the fix)
- `curl -L -I --max-time 20 https://forum.snapcraft.io/t/uc20-uc22-full-disk-encryption-hook-interface/24439` (HTTP 200)
- `curl -L --max-time 20 https://forum.snapcraft.io/t/uc20-uc22-full-disk-encryption-hook-interface/24439 | rg 'id="heading--fde-setup"|meta/hooks/fde-setup|snapctl fde-setup-request'`
- `rg -n 'https://snapcraft.io/docs/uc20-fde-hooks' docs/explanation` (no matches)
- `make -C docs html`
- `git diff --check`

## Note

I also ran targeted `markdownlint-cli2` with the repository config against the two touched files. It reports existing file-wide line-length/heading/list spacing violations in these files; this PR intentionally leaves that unrelated formatting untouched.
