### PR TITLE
Remove shell prompts from modem-manager debug commands

### DIFF
--- a/docs/explanation/system-snaps/modem-manager/debug.md
+++ b/docs/explanation/system-snaps/modem-manager/debug.md
@@ -23,16 +23,16 @@ Changing the  **debug**  configuration option has immediate effect and also affe
 
 **Example:**  Enable debug feature
 ```bash
-$ snap set modem-manager debug.enable=true
+snap set modem-manager debug.enable=true
 ```
 **Example:**  Disable debug feature.
 ```bash
-$ snap set modem-manager debug.enable=false
+snap set modem-manager debug.enable=false
 ```
 ## Viewing logs
 
 The debug information, when enabled, will be available in the journal and can be viewed with:
 ```bash
-$ journalctl --no-pager -u snap.modem-manager.modemmanager.service
+journalctl --no-pager -u snap.modem-manager.modemmanager.service
 ```
 


### PR DESCRIPTION
Removes leading `$` prompts from command examples to make the commands easier to copy and consistent with the formatting cleanup requested in canonical/open-documentation-academy#344.

Related to canonical/open-documentation-academy#344