### PR TITLE
docs: clarify system-user assertion seeding

### DIFF
--- a/docs/how-to-guides/image-creation/use-ubuntu-image.md
+++ b/docs/how-to-guides/image-creation/use-ubuntu-image.md
@@ -105,11 +105,11 @@ These additional snaps can include {ref}`custom snaps <how-to-guides-image-creat
 (ref-use-ubuntu-image_extra-assertions)=
 ## Extra assertions
 
-Arbitrary assertions, such as {ref}`system-user assertions <reference-assertions-system-user>`, can be included in the final image using the `--assertion` argument pointing to a file containing one or more assertions. This can help you, for example, in creating a system user or choosing a snap store proxy without the added manual configuration after the installation is complete.
+Extra assertions, such as store assertions or {ref}`system-user assertions <reference-assertions-system-user>`, can be included in the final image using the `--assertion` argument pointing to a file containing one or more assertions. This can help you, for example, in creating a system user or choosing a snap store proxy without the added manual configuration after the installation is complete.
 
 ```{note}
 
-System-user assertions can only be included using `ubuntu-image` if the model grade is set to `dangerous` and the assertion does not contain a password (use public key authentication instead).
+When using `--assertion` to seed a `system-user` assertion, the model must have `grade: dangerous`. Seeded `system-user` assertions must use public key authentication and must not contain a password.
 ```
 
 It is possible to add assertions of any kind except for `snap-declaration`, `snap-revision`, `model`, `serial` and `validation-set`.

--- a/docs/how-to-guides/manage-ubuntu-core/add-a-system-user.md
+++ b/docs/how-to-guides/manage-ubuntu-core/add-a-system-user.md
@@ -17,6 +17,11 @@ Some systems, however, suppress _console-conf_ and its user creation.
 
 To create a system user on these systems, you must create and sign a {ref}`system-user assertion <reference-assertions-system-user>`. This assertion can then be injected into the {ref}`ubuntu-seed <ref-inside-ubuntu-core_volume-layouts>` partition using the {ref}`ubuntu-image utility <ref-use-ubuntu-image_extra-assertions>`. Alternatively, it can be embedded within a file called `auto-import.assert` that's added to the system via the root directory of a removable USB storage device that must be formatted with a widely supported filesystem such as ext4, FAT32, or any other filesystem supported by the device Linux kernel. This process is covered below.
 
+```{note}
+
+When using `ubuntu-image` to seed a `system-user` assertion, the model must have `grade: dangerous`. The seeded assertion must use public key authentication and must not contain a password. Password-based `system-user` assertions are only suitable for the removable-media `auto-import.assert` workflow described below.
+```
+
 ```{admonition} Managed and unmanaged systems
 :class: caution
 
@@ -193,4 +198,3 @@ Simply copy `auto-import.assert` to the root directory of a USB drive, insert it
 If you can log in with the username and password, the system user has been created.
 
 You can also use the `snap known system-user` command. If there is a system user, the signed assertion is output.
-


### PR DESCRIPTION
## Summary
- clarify that extra assertions are generally supported by ubuntu-image
- document that seeded system-user assertions require grade: dangerous
- note that seeded system-user assertions must use SSH keys and not passwords
- clarify that password-based system-user assertions apply to removable-media auto-import.assert

Fixes #291

## Testing
- make html