### PR TITLE
docs: fix broken uc20-fde-hooks links

### DIFF
--- a/docs/explanation/full-disk-encryption-op-tee.md
+++ b/docs/explanation/full-disk-encryption-op-tee.md
@@ -13,7 +13,7 @@ OP-TEE is an open source Trusted Execution Environment (TEE) for Arm systems. It
 
 Snapd (the snap daemon) integrates with a Canonical-provided [OP-TEE TA](https://github.com/canonical/optee-uc-fde) that knows how to seal and unseal LUKS keys inside the secure world.
 
-During installation, snapd decides how to seal the LUKS disk keys. It first looks for a kernel [`fde-setup` hook](https://snapcraft.io/docs/uc20-fde-hooks#heading--fde-setup), then for the dedicated OP-TEE TA, and finally falls back to TPM-backed sealing. The selection is automatic and requires no user input.
+During installation, snapd decides how to seal the LUKS disk keys. It first looks for a kernel [`fde-setup` hook](https://snapcraft.io/docs/reference/development/supported-snap-hooks/#heading--fde), then for the dedicated OP-TEE TA, and finally falls back to TPM-backed sealing. The selection is automatic and requires no user input.
 
 When OP-TEE is selected, snapd asks the TA to seal the disk key. The TA performs the encryption inside the secure world and hands back the sealed key. The encrypted key is stored on disk so that it can be used to decrypt the LUKS partition later. Note that only the TA can decrypt the sealed key, so storing the sealed key is safe.
 

--- a/docs/explanation/full-disk-encryption.md
+++ b/docs/explanation/full-disk-encryption.md
@@ -22,7 +22,7 @@ The following factors affect how a device is encrypted:
 - {ref}`Disabling encryption <ref-full-disk-encryption_disabling-encryption>`: an optional parameter that can disable encryption
 - {ref}`Model grade <ref-full-disk-encryption_model-grade>`: interacts with _storage-safety_ to set the device constraints 
 
-For a non-standard (non-UEFI+TPM platform) FDE platform, such as a Raspberry Pi or other ARM devices, implementation is board-specific and will typically involve creating custom gadget and kernel snaps. UC20/UC22, however, do provide a helper mechanism, via a hook interface, to ensure the integrity of any subsequently executed or accessed data. See the [full-disk-encryption hook interface](https://snapcraft.io/docs/uc20-fde-hooks) for further details.
+For a non-standard (non-UEFI+TPM platform) FDE platform, such as a Raspberry Pi or other ARM devices, implementation is board-specific and will typically involve creating custom gadget and kernel snaps. UC20/UC22, however, do provide a helper mechanism, via a hook interface, to ensure the integrity of any subsequently executed or accessed data. See the [full-disk-encryption hook interface](https://snapcraft.io/docs/reference/development/supported-snap-hooks/#heading--fde) for further details.
 
 (ref-full-disk-encryption_storage-layouts)=
 ## Storage layouts


### PR DESCRIPTION
Fixes #381

The `https://snapcraft.io/docs/uc20-fde-hooks` page returns 404. This updates both references to point at the current Snapcraft documentation for the full-disk-encryption hook:

https://snapcraft.io/docs/reference/development/supported-snap-hooks/#heading--fde

**Files changed:**
- `docs/explanation/full-disk-encryption.md`
- `docs/explanation/full-disk-encryption-op-tee.md`

Made with [Cursor](https://cursor.com)