### PR TITLE
docs: fix model service link and VPN track guidance

### DIFF
--- a/docs/explanation/stores/dedicated-snap-store.md
+++ b/docs/explanation/stores/dedicated-snap-store.md
@@ -62,7 +62,7 @@ See {ref}`Add customs snaps <how-to-guides-image-creation-add-custom-snaps>` for
 
 ## Device authentication
 
-When a device boots for the first time, it obtains a signed {ref}`serial assertion <reference-assertions-serial>` from a [Model Service](https://ubuntu.com/internet-of-things/appstore/docs/how-to/configure-model-service/) or [Serial vault](https://canonical-serial-vault.readthedocs-hosted.com/). Each device can then be authenticated with the dedicated Snap Store using the model assertion's _model name_ and an authentication token called a **macaroon**. 
+When a device boots for the first time, it obtains a signed {ref}`serial assertion <reference-assertions-serial>` from a [Model Service](https://documentation.ubuntu.com/dedicated-snap-store/how-to/configure-model-service/) or [Serial vault](https://canonical-serial-vault.readthedocs-hosted.com/). Each device can then be authenticated with the dedicated Snap Store using the model assertion's _model name_ and an authentication token called a **macaroon**. 
 
 ![image](/images/brand-store-4.png)
 

--- a/docs/explanation/system-snaps/network-manager/how-to-guides/configure-vpn-connections.md
+++ b/docs/explanation/system-snaps/network-manager/how-to-guides/configure-vpn-connections.md
@@ -1,7 +1,7 @@
 (explanation-system-snaps-network-manager-how-to-guides-configure-vpn-connections)=
 # Configure VPN connections
 
-VPN support requires both the use of `core22` and network-manager from a `22/*` channel. Currently, two types of VPN are supported:
+VPN support requires network-manager installed from the track that matches your Ubuntu Core base — for example `22/stable` on Core 22 or `24/stable` on Core 24. Using a mismatched track (such as the Core 22 track on a Core 24 system) can prevent VPN connections from being created. See {ref}`Install NetworkManager <explanation-system-snaps-network-manager-install-networkmanager>` for track details. Currently, two types of VPN are supported:
 
 - {ref}`OpenVPN <ref-configure-vpn-connections_openvpn>`
 - {ref}`WireGuard <ref-configure-vpn-connections_wireguard>`


### PR DESCRIPTION
Fixes #383
Fixes #384

**Model service link (#383)**  
The Device authentication section linked to a URL that fails when followed from the published Ubuntu Core docs site. This points to the Dedicated Snap Store documentation path that resolves correctly.

**VPN track guidance (#384)**  
The VPN guide incorrectly implied Core 22 + `22/*` is always required. VPN setup needs the network-manager snap track that matches the device base (e.g. `24/stable` on Core 24). Mismatched tracks can block VPN connection creation.

**Files changed**
- `docs/explanation/stores/dedicated-snap-store.md`
- `docs/explanation/system-snaps/network-manager/how-to-guides/configure-vpn-connections.md`

Made with [Cursor](https://cursor.com)