### PR TITLE
docs: clarify model assertion components

### DIFF
--- a/docs/reference/assertions/model.md
+++ b/docs/reference/assertions/model.md
@@ -106,7 +106,9 @@ A [component](https://snapcraft.io/docs/components) is an optional part of a sna
 
 Components are declared inside the relevant entry in the model's `snaps` list. Each component is listed by name under a `components` map, with a `presence` value of either `required` or `optional`. If a component is required, it must be present in the image seed.
 
-The `presence` value can be provided as a string shortcut or as a map. The following example adds optional NVIDIA components to the `pc-kernel` snap entry:
+The `presence` value can be provided as a string shortcut or as a map. The map form can also specify the modes for which a component must be present. Component modes must be a subset of the modes specified for the snap and default to the snap's modes.
+
+The following example adds optional NVIDIA components to the `pc-kernel` snap entry, with one component limited to `run` mode:
 
 ```json
 {
@@ -116,7 +118,8 @@ The `presence` value can be provided as a string shortcut or as a map. The follo
     "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
     "components": {
         "nvidia-590-uda-ko": {
-            "presence": "optional"
+            "presence": "optional",
+            "modes": ["run"]
         },
         "nvidia-590-uda-user": "optional"
     }

--- a/docs/reference/assertions/model.md
+++ b/docs/reference/assertions/model.md
@@ -38,7 +38,6 @@ authority-id:          <authority account id>
 base:                  <string>
 brand-id               <account id>
 classic                <true|false>   # Optional
-components:            <list[dict]>   # Optional, see below for details
 display-name           <descriptive string>
 grade:                 <string>
 model                  <model id>
@@ -98,26 +97,30 @@ For "recovery" and "install" modes, "ephemeral" can be used. This will install t
   * `presence` *(optional)*:  set to mark a snap whose absence will not fail installation or recovery. Can be either _optional_ or _required_ but defaults to _required_.
     * A _required_ snap cannot be removed from the system.
     * An _optional_ snap is not added to the {ref}`ubuntu-seed <explanation-core-elements-storage-layout>` partition when the image is created with {ref}`ubuntu-image <how-to-guides-image-creation-use-ubuntu-image>` unless the `--snap` option is used to add the snap explicitly. Optional snaps can be used to adapt the same base model for different hardware configurations, deployment objectives, and for use with a dynamic modelling agent.
+  * `components` *(optional)*: snap components to include in the image. See the following Components section for details.
   * `default-channel` *(optional)*: initial tracking channel for the snap, default is “latest/stable”.
 
 ### Components
 
-A [component](https://snapcraft.io/docs/components) is part of a snap that has been declared as optional. Models need to specify which snap components should be included in an image as they are not installed by default.
+A [component](https://snapcraft.io/docs/components) is an optional part of a snap. Model assertions specify which snap components should be included in an image, as components are not installed by default.
 
-They're added as a structured list with a single `presence` attribute for whether each component is required or options. If required, the component must be in the image seed.
+Components are declared inside the relevant entry in the model's `snaps` list. Each component is listed by name under a `components` map, with a `presence` value of either `required` or `optional`. If a component is required, it must be present in the image seed.
 
-The modes for which the component must be present can be specified as well. Syntax is as follows:
+The `presence` value can be provided as a string shortcut or as a map. The following example adds optional NVIDIA components to the `pc-kernel` snap entry:
 
-```text
-    components:                                 # optional
-      <component-name-1>:
-        presence: "optional"|"required"
-        modes: [<mode-specifier>]               # list of modes, optional
-                                                # must be a subset of snap one
-                                                # defaults to the same modes
-                                                # as the snap
-      <component-name-2>: "required"|"optional" # presence, shortcut
-                                                # syntax
+```json
+{
+    "name": "pc-kernel",
+    "type": "kernel",
+    "default-channel": "26.04/beta",
+    "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+    "components": {
+        "nvidia-590-uda-ko": {
+            "presence": "optional"
+        },
+        "nvidia-590-uda-user": "optional"
+    }
+}
 ```
 
 ### Validation sets


### PR DESCRIPTION
## Summary
- clarify that model assertion components are declared inside snap entries
- replace the component modes snippet with a JSON example
- remove the misleading top-level components field from the model field list

Fixes #396

## Testing
- make html

Note: `make vale TARGET=reference/assertions/model.md` failed before checking the file because the local Vale setup could not resolve the spellcheck dictionary path (`unable to resolve dicpath`).