### PR TITLE
docs: fix links following docs migration

### DIFF
--- a/docs/explanation/community-engagement.md
+++ b/docs/explanation/community-engagement.md
@@ -24,7 +24,7 @@ Ubuntu Core does not have a its own code repository.  It is instead built entire
 - **[kernel snaps](https://github.com/canonical/sample-kernels)** define the Linux kernel to run on each system.
 - **[base snaps](https://snapcraft.io/docs/base-snaps)** provide the run-time environment and a minimal set of libraries.
 
-In addition to the above, our [Documentation](https://ubuntu.com/core/docs) is hosted and built from [https://github.com/canonical/ubuntu-core-docs](https://github.com/canonical/ubuntu-core-docs). See {ref}`How to contribute <ref-contributing_contribute-to-our-docs>` for further details.
+In addition to the above, our {ref}`Documentation <ref-index_ubuntu-core-documentation>` is hosted and built from [https://github.com/canonical/ubuntu-core-docs](https://github.com/canonical/ubuntu-core-docs). See {ref}`How to contribute <ref-contributing_contribute-to-our-docs>` for further details.
 
 ## Contributions
 

--- a/docs/explanation/core-elements/storage-layout.md
+++ b/docs/explanation/core-elements/storage-layout.md
@@ -67,7 +67,7 @@ Stores device identity backup data and data to facilitate recovery or re-install
 
 This partition is mandatory on encrypted systems where it should have a minimum size of approximately 20+MB to handle volume and file system creation (32MB is recommended).
 
-From _snapd 2.57+_, snaps can save small amounts of persistent data to the _ubuntu-save_ partition. This location is accessible from the [SNAP_SAVE_DATA](https://snapcraft.io/docs/environment-variables#heading--snap-save-data) environment variable.
+From _snapd 2.57+_, snaps can save small amounts of persistent data to the _ubuntu-save_ partition. This location is accessible from the [SNAP_SAVE_DATA](https://snapcraft.io/docs/reference/development/environment-variables/#snap-save-data) environment variable.
 
 This data might include certificates, data blobs, or configuration files, to help snaps function. This data will survive a {ref}`factory reset <ref-recovery-modes_factory-reset>`, and consequently, the stored data should be device-oriented and not specific to a particular user of the device.
 

--- a/docs/explanation/cve-remediation.md
+++ b/docs/explanation/cve-remediation.md
@@ -48,7 +48,7 @@ Application snaps bundle their own dependencies. CVEs affecting those dependenci
 
 * The party maintaining the gadget snap is responsible for assessing, fixing, and releasing updates.
 
-For [Canonical-maintained gadget snaps](https://documentation.ubuntu.com/core/reference/gadget-snap-format/#example-gadget-snaps), Canonical tracks relevant CVEs and provides updated snap revisions when fixes are available. For example, on supported x86 platforms, Canonical currently maintains GRUB and delivers security fixes through updated gadget snap revisions.
+For {ref}`Canonical-maintained gadget snaps <reference-gadget-snap-format-example-gadget-snaps>`, Canonical tracks relevant CVEs and provides updated snap revisions when fixes are available. For example, on supported x86 platforms, Canonical currently maintains GRUB and delivers security fixes through updated gadget snap revisions.
 
 For third-party or device-vendor–maintained gadget snaps, responsibility for bootloader maintenance (such as U-Boot) and associated CVE remediation lies with the gadget snap publisher. Updated gadget snap revisions must be released to address vulnerabilities, and devices will receive them through the normal snap refresh mechanism.
 

--- a/docs/explanation/how-installation-works.md
+++ b/docs/explanation/how-installation-works.md
@@ -32,7 +32,7 @@ The first three (1-3) are also described in the {ref}`recovery mode <explanation
 
 A {ref}`gadget <reference-gadget-snap-format>` can optionally define an _install-device hook_ . This is invoked from **install mode** before rebooting into **run mode**, between steps 4 and 5 above, and also after a {ref}`factory reset <ref-recovery-modes_factory-reset>`, to perform early hardware and firmware configuration.
 
-The [snapctl system-mode](https://snapcraft.io/docs/using-snapctl#heading--system-mode) command can be run during execution of the hook to detect which mode the install-device hook has been executed under.
+The [snapctl system-mode](https://snapcraft.io/docs/how-to-guides/snap-development/use-snapctl/#system-mode) command can be run during execution of the hook to detect which mode the install-device hook has been executed under.
 
 All partitions are created and mounted when the install-device hook runs.
 

--- a/docs/explanation/refresh-control.md
+++ b/docs/explanation/refresh-control.md
@@ -241,7 +241,7 @@ In this example, if `roadmr-gating` is installed on a device, `roadmr-gated` wil
 
 ```{admonition} Installing new snaps after updated validation assertion
 :class: caution
-If a validation assertions is updated to include additional snaps, the new snaps will not be installed automatically. They will instead need to be installed locally through the _snap_ command or through the [snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/Asynchronous/manageSnaps).
+If a validation assertion is updated to include additional snaps, the new snaps will not be installed automatically. They will instead need to be installed locally through the _snap_ command or through the [snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/Asynchronous/manageSnaps).
 ```
 
 ## Revoking assertion validity

--- a/docs/explanation/refresh-control.md
+++ b/docs/explanation/refresh-control.md
@@ -11,7 +11,7 @@ Snaps in Ubuntu Core update automatically, and by default, the *snapd* daemon ch
 
 However, some projects can benefit from holding a deployed snap, or a set of snaps, at a tested _revision_ until any new release is separately validated, and this requires refresh control.
 
-A snap’s [revision](https://snapcraft.io/docs/glossary#heading--revision) is an automatic number assigned by the Snap Store to give each snap build a unique identity within its channel. Refresh control allows specific snaps to be kept at a specified revision, even when a new or different revision of a snap is released.
+A snap’s [revision](https://snapcraft.io/docs/reference/glossary/#revision) is an automatic number assigned by the Snap Store to give each snap build a unique identity within its channel. Refresh control allows specific snaps to be kept at a specified revision, even when a new or different revision of a snap is released.
 
 ```{admonition} Refresh control with validation sets
 :class: tip
@@ -241,7 +241,7 @@ In this example, if `roadmr-gating` is installed on a device, `roadmr-gated` wil
 
 ```{admonition} Installing new snaps after updated validation assertion
 :class: caution
-If a validation assertions is updated to include additional snaps, the new snaps will not be installed automatically. They will instead need to be installed locally through the _snap_ command or through the [snapd REST API](https://snapcraft.io/docs/snapd-api#heading--snaps-post).
+If a validation assertions is updated to include additional snaps, the new snaps will not be installed automatically. They will instead need to be installed locally through the _snap_ command or through the [snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/Asynchronous/manageSnaps).
 ```
 
 ## Revoking assertion validity

--- a/docs/explanation/secure-device-onboarding.md
+++ b/docs/explanation/secure-device-onboarding.md
@@ -160,11 +160,11 @@ Your gadget snap acts as the bridge between snapd and your specific hardware. It
 
 ### Prepare-device hook
 
-This hook sets up the hardware identity key pair during installation. For details on implementation—including how to work with TPMs, HSMs, and detect factory mode—see the [snapd prepare-device hook documentation](https://snapcraft.io/docs/the-prepare-device-hook).
+This hook sets up the hardware identity key pair during installation. For details on implementation—including how to work with TPMs, HSMs, and detect factory mode—see the [snapd prepare-device hook documentation](https://snapcraft.io/docs/reference/development/yaml-schemas/the-gadget-snap/#prepare-device-hook).
 
 ### Prepare-serial-request hook
 
-This hook runs during device registration to sign the nonce with the hardware identity private key, proving the request is genuine. For implementation details and the expected input/output format, see the [snapd prepare-serial-request hook documentation](https://snapcraft.io/docs/the-prepare-serial-request-hook).
+This hook runs during device registration to sign the nonce with the hardware identity private key, proving the request is genuine. For implementation details and the expected input/output format, see the [snapd prepare-serial-request hook documentation](https://snapcraft.io/docs/reference/development/yaml-schemas/the-gadget-snap/#prepare-serial-hook).
 
 ## Remodeling considerations
 

--- a/docs/explanation/security-and-sandboxing.md
+++ b/docs/explanation/security-and-sandboxing.md
@@ -75,7 +75,7 @@ Under the hood, the application runner does the following:
 
 The snap packaging system employs various cryptographic technologies to secure local and remote snap operations.
 
-Locally, these are handled by the snap daemon, *snapd*, while remote connections require mediation between snapd and the [Snap Store](https://snapcraft.io/docs/glossary#heading--snap-store), which supports its own set of cryptographic technologies. Both sets of these are listed below.
+Locally, these are handled by the snap daemon, *snapd*, while remote connections require mediation between snapd and the [Snap Store](https://snapcraft.io/docs/reference/glossary/#snap-store), which supports its own set of cryptographic technologies. Both sets of these are listed below.
 
 ### Snapd (snap daemon) cryptography
 
@@ -113,7 +113,7 @@ When a snap is installed, its metadata is examined and is used to derive **AppAr
 
    As already mentioned, each command runs under an app-specific default policy that may be extended through declared interfaces which are expressed in the metadata as `plugs` and `slots`. AppArmor policy violations in strict mode snaps will be denied access, and typically have errno set to `EACCES`. The violation will typically be logged.
 
-  See [AppArmor violations](https://snapcraft.io/docs/debug-snaps#heading--apparmor) for help tracking AppArmor problems.
+  See [AppArmor violations](https://snapcraft.io/docs/how-to-guides/snap-development/debug-snaps/#understanding-apparmor-violations) for help tracking AppArmor problems.
 
 ### Seccomp
 
@@ -121,7 +121,7 @@ When a snap is installed, its metadata is examined and is used to derive **AppAr
    
    Processes with seccomp policy violations will be denied access to the system call with errno set to `EPERM` (snapd releases prior to 2.32 receive `SIGSYS`) and the violation is logged.
 
-  See [Seccomp violations](https://snapcraft.io/docs/debug-snaps#heading--seccomp) for help tracking Seccomp problems.
+  See [Seccomp violations](https://snapcraft.io/docs/how-to-guides/snap-development/debug-snaps/#understanding-seccomp-violations) for help tracking Seccomp problems.
 
 ### Device cgroup
 

--- a/docs/explanation/security-and-sandboxing.md
+++ b/docs/explanation/security-and-sandboxing.md
@@ -79,7 +79,7 @@ Locally, these are handled by the snap daemon, *snapd*, while remote connections
 
 ### Snapd (snap daemon) cryptography
 
-* **Digital signatures for [assertions](https://ubuntu.com/core/docs/reference/assertions)**
+* **Digital signatures for {ref}`assertions <ref-index_assertions>`**
 </br>SHA3-384 and SHA512 for hashing, OpenPGP v4 signatures with RSA 4096/8192 keys
 * **Hashing of snaps**</br>
 SHA3-384
@@ -92,7 +92,7 @@ Snapd uses them via [gopkg.in/macaroon.v1](https://github.com/go-macaroon/macaro
 
 ### Snap Store cryptography
 
-* **Digital signatures for [assertions](https://ubuntu.com/core/docs/reference/assertions)**</br>
+* **Digital signatures for {ref}`assertions <ref-index_assertions>`**</br>
 The key ID of the signing key is encoded with SHA3-384, and the assertion is signed with either 4096-bit RSA or 8192-bit RSA
 * **Hashing of artifacts**</br>
 The store generates many hashes of an uploaded artifact using SHA3-384, SHA256 and SHA512 to ensure the uniqueness and integrity of the artifact.

--- a/docs/explanation/stores/store-overview.md
+++ b/docs/explanation/stores/store-overview.md
@@ -9,7 +9,7 @@ myst:
 
 Ubuntu Core includes access to the Canonical's [Snap Store](https://snapcraft.io/store) by default. This allows any developer to easily release and support apps for multiple architectures, on multiple release channels, from daily builds to stable releases.
 
-See [Releasing to the Snap Store](https://snapcraft.io/docs/releasing-to-the-snap-store) for more details on how to publish and distribute snaps to devices from the Snap Store.
+See [Publish a snap](https://documentation.ubuntu.com/snapcraft/latest/how-to/publishing/publish-a-snap/) for more details on how to publish and distribute snaps to devices from the Snap Store.
 
 ## Enterprise Store
 
@@ -41,7 +41,7 @@ Snaps can be registered using the `snapcraft` tool or via the web. Snaps should 
 -   execute `snapcraft login` and authenticate using the brand/umbrella account
 -   once authenticated register the snap name(s) with `snapcraft register   yoursnapname`
 
-For more details on this process, see [Registering your app name](https://snapcraft.io/docs/registering-your-app-name).
+For more details on this process, see [Register a snap](https://documentation.ubuntu.com/snapcraft/latest/how-to/publishing/register-a-snap/).
 
 ### Registering snaps via the web
 

--- a/docs/explanation/stores/store-scoping.md
+++ b/docs/explanation/stores/store-scoping.md
@@ -81,7 +81,7 @@ If a customer has devices already flashed and sitting on shelves with a snapd ve
 
 If a customer has devices on shelves flashed with a version of snapd _older_ than 2.36, they should also update autonomously, with snapd updating first before migrating the assertions to the newer formats. This assumes refreshing is correctly in place.
 
-Lastly, if a customer has **existing** snaps that require **new** auto-connections in newer revisions, they should consider defining the [assumes attribute](https://snapcraft.io/docs/snapcraft-top-level-metadata#heading--assumes) in their snapcraft.yaml file. 
+Lastly, if a customer has **existing** snaps that require **new** auto-connections in newer revisions, they should consider defining the [assumes attribute](https://documentation.ubuntu.com/snapcraft/stable/reference/snapcraft-yaml/#assumes) in their snapcraft.yaml file.
 
 Pre-existing auto-connections in a pre store-scoped snap-declaration should not be affected because of the assertion format handling.
 

--- a/docs/explanation/stores/store-scoping.md
+++ b/docs/explanation/stores/store-scoping.md
@@ -31,7 +31,7 @@ timestamp: 2022-01-26T11:15:49.885580Z
 sign-key-sha3-384: some-account-key
 ```
 
-With the release of [snapd](https://snapcraft.io/docs/glossary#heading--snapd)  version _2.36_ in 2018, the snap-declaration assertion was updated to include a {ref}`dedicated snap store <ref-dedicated-snap-store_dedicated-snap-store>` definition for each granted interface:
+With the release of [snapd](https://snapcraft.io/docs/reference/glossary/#snapd)  version _2.36_ in 2018, the snap-declaration assertion was updated to include a {ref}`dedicated snap store <ref-dedicated-snap-store_dedicated-snap-store>` definition for each granted interface:
 
 ```yaml
 type: snap-declaration

--- a/docs/explanation/system-snaps/console-conf/model.md
+++ b/docs/explanation/system-snaps/console-conf/model.md
@@ -6,8 +6,7 @@ myst:
 
 # Including console-conf in a model assertion
 
-[Model
-assertions](https://documentation.ubuntu.com/core/reference/assertions/model/)
+{ref}`Model assertions <reference-assertions-model>`
 define the snaps that a system will install on first boot.
 
 Adding console-conf would be a matter of adding a snap to the snaps list in the

--- a/docs/how-to-guides/container-deployment/deploy-docker-from-a-snap.md
+++ b/docs/how-to-guides/container-deployment/deploy-docker-from-a-snap.md
@@ -161,7 +161,7 @@ snapcraft -v
 ```
 This will create: `rabbitmq-docker-guide_demo_amd64.snap`
 
-You could use [`--destructive-mode`](https://documentation.ubuntu.com/snapcraft/stable/reference/build-environment-options/#destructive-mode) flag to build it natively, instead of using LXD.
+You could use the [`--destructive-mode`](https://documentation.ubuntu.com/snapcraft/stable/reference/build-environment-options/#destructive-mode) flag to build it natively, instead of using LXD.
 This speeds up the build and is safe because building this snap makes no changes on the host and doesn't link against any of the host shared libraries (e.g. by using build/stage packages).
 
 ## Install the snap

--- a/docs/how-to-guides/container-deployment/deploy-docker-from-a-snap.md
+++ b/docs/how-to-guides/container-deployment/deploy-docker-from-a-snap.md
@@ -161,7 +161,7 @@ snapcraft -v
 ```
 This will create: `rabbitmq-docker-guide_demo_amd64.snap`
 
-You could use [`--destructive-mode`](https://snapcraft.io/docs/build-options#heading--snapcraft) flag to build it natively, instead of using LXD.
+You could use [`--destructive-mode`](https://documentation.ubuntu.com/snapcraft/stable/reference/build-environment-options/#destructive-mode) flag to build it natively, instead of using LXD.
 This speeds up the build and is safe because building this snap makes no changes on the host and doesn't link against any of the host shared libraries (e.g. by using build/stage packages).
 
 ## Install the snap

--- a/docs/how-to-guides/container-deployment/deploy-docker-from-a-snap.md
+++ b/docs/how-to-guides/container-deployment/deploy-docker-from-a-snap.md
@@ -169,7 +169,7 @@ This speeds up the build and is safe because building this snap makes no changes
 ```shell
 sudo snap install --dangerous ./rabbitmq-docker-guide_demo_amd64.snap
 ```
-The [`--dangerous`](https://snapcraft.io/docs/install-modes#heading--dangerous) flag is set because this is a locally built, unsigned snap.
+The [`--dangerous`](https://snapcraft.io/docs/install-modes#dangerous-mode) flag is set because this is a locally built, unsigned snap.
 
 Connect the following [interfacess](https://snapcraft.io/docs/interfaces):
 ```shell

--- a/docs/how-to-guides/image-creation/board-enablement.md
+++ b/docs/how-to-guides/image-creation/board-enablement.md
@@ -176,6 +176,7 @@ Or
 snap known --remote model series=16 brand-id=canonical model=pi3
 ```
 
+(how-to-guides-image-creation-board-enablement-image-building)=
 ## Image building
 
 Images are built from a model assertion using [ubuntu-image](https://github.com/canonical/ubuntu-image), a tool to generate a bootable image. It can be installed on a [snap-supporting Linux system](https://snapcraft.io/docs/installing-snapd) as follows:

--- a/docs/how-to-guides/image-creation/build-a-gadget-snap.md
+++ b/docs/how-to-guides/image-creation/build-a-gadget-snap.md
@@ -136,7 +136,7 @@ The following is an annotated snapcraft.yaml file that can be used as the basis 
 ```yaml
 # A template snapcraft.yaml
 # For a full specification of the snapcraft.yaml, please see:
-# https://snapcraft.io/docs/snapcraft-yaml-reference
+# https://documentation.ubuntu.com/snapcraft/stable/reference/snapcraft-yaml/
 
 # Do not feel obligated to perfectly adhere to this style, but strive to include
 # as much metadata as possible.
@@ -186,7 +186,7 @@ description: |
 
 # If you want the gadget.yaml to refer to assets provided by the kernel
 # instead of this snap, use this key. See:
-# https://snapcraft.io/docs/snapcraft-top-level-metadata
+# https://documentation.ubuntu.com/snapcraft/stable/reference/snapcraft-yaml/#top-level-keys
 assumes: [kernel-assets]
 
 # At a minimum the snap should build natively.

--- a/docs/how-to-guides/image-creation/build-a-gadget-snap.md
+++ b/docs/how-to-guides/image-creation/build-a-gadget-snap.md
@@ -395,7 +395,7 @@ Generated snap metadata
 Created snap package amd64-gadget_0.1_amd64.snap
 ```
 
-See [Image building](https://documentation.ubuntu.com/core/how-to-guides/image-creation/board-enablement/#image-building) for instructions on how to build a bootable image that includes the gadget snap.
+See {ref}`Image building <how-to-guides-image-creation-board-enablement-image-building>` for instructions on how to build a bootable image that includes the gadget snap.
 
 ### Cross-building
 
@@ -440,4 +440,4 @@ Generated snap metadata
 Created snap package virt_22-1_riscv64.snap
 ```
 
-See [Architectures](https://snapcraft.io/docs/architectures) for more details on defining architectures and [Image building](https://documentation.ubuntu.com/core/how-to-guides/image-creation/board-enablement/#image-building) for instructions on how to build a bootable image that includes the gadget snap.
+See [Architectures](https://snapcraft.io/docs/architectures) for more details on defining architectures and {ref}`Image building <how-to-guides-image-creation-board-enablement-image-building>` for instructions on how to build a bootable image that includes the gadget snap.

--- a/docs/how-to-guides/image-creation/build-a-gadget-snap.md
+++ b/docs/how-to-guides/image-creation/build-a-gadget-snap.md
@@ -361,11 +361,11 @@ There are typically two methods for building a gadget snap, _native building_ an
 
 ### Requirements
 
-The build system must support [snap](https://snapcraft.io/docs/installing-snapd), and have both the [Snapcraft](https://snapcraft.io/docs/snapcraft-overview) build tool and the [LXD](https://canonical.com/lxd/install) virtualisation platform installed, all of which are provided by any Ubuntu release. Ensure your user has been added to the `lxd` group and you've initialized LXD with `lxd init` before proceeding. See [Set up Snapcraft](https://documentation.ubuntu.com/snapcraft/stable/how-to/setup/set-up-snapcraft/#install-lxd) for further details.
+The build system must support [snap](https://snapcraft.io/docs/installing-snapd), and have both the [Snapcraft](https://snapcraft.io/docs/snapcraft-overview) build tool and the [LXD](https://canonical.com/lxd/install) virtualisation platform installed, all of which are provided by any Ubuntu release. Ensure your user has been added to the `lxd` group and you've initialized LXD with `lxd init` before proceeding. See [Set up Snapcraft](https://documentation.ubuntu.com/snapcraft/stable/how-to/set-up-snapcraft/#install-lxd) for further details.
 
 ### Native building
 
-This method builds a gadget snap on the same hardware that the gadget is intended for. The following example will build the [22-amd64-pc](https://github.com/canonical/iot-field-gadget-snap/tree/22-amd64-pc) gadget snap on an x86 generic PC.
+This method builds a gadget snap on the same hardware that the gadget is intended for. The following example will build the [amd64 PC gadget](https://github.com/canonical/iot-field-gadget-snap/tree/22/pc) from the `22` branch on an x86 generic PC.
 
 #### Checkout the branch
 
@@ -375,11 +375,12 @@ With the requirements met, open a terminal and clone the repository:
 git clone https://github.com/canonical/iot-field-gadget-snap.git
 ```
 
-Next,`cd` into the directory and _checkout_ the `22-amd-pc` branch:
+Next, `cd` into the directory, check out the `22` branch, and enter the `pc` directory:
 
 ```
 cd iot-field-gadget-snap
-git checkout 22-amd64-pc
+git checkout 22
+cd pc
 ```
 
 #### Build with Snapcraft
@@ -394,7 +395,7 @@ Generated snap metadata
 Created snap package amd64-gadget_0.1_amd64.snap
 ```
 
-See [Image building](https://ubuntu.com/core/docs/board-enablement#heading--image-building) for instructions on how to build a bootable image that includes the gadget snap.
+See [Image building](https://documentation.ubuntu.com/core/how-to-guides/image-creation/board-enablement/#image-building) for instructions on how to build a bootable image that includes the gadget snap.
 
 ### Cross-building
 
@@ -402,7 +403,7 @@ Cross-building allows a gadget snap to be built on an architecture different fro
 
 Snapcraft uses LXD, or [optionally Multipass](https://snapcraft.io/docs/build-options), to isolate the host system from the build system. Crucially, both LXD and Multipass also allow for the _build_ architecture to differ from the _host_ architecture. This is handled by the `architecture` stanza in the `snapcraft.yaml` file for the gadget snap.
 
-The following example will build the [22-riscv-pc](https://github.com/canonical/iot-field-gadget-snap/tree/22-amd64-pc) gadget snap on an x86 PC.
+The following example will build the [22-riscv64-virt](https://github.com/canonical/iot-field-gadget-snap/tree/22-riscv64-virt) gadget snap on an x86 PC.
 
 #### Checkout the branch
 
@@ -439,4 +440,4 @@ Generated snap metadata
 Created snap package virt_22-1_riscv64.snap
 ```
 
-See [Architectures](https://snapcraft.io/docs/architectures) for more details on defining architectures and [Image building](https://ubuntu.com/core/docs/board-enablement#heading--image-building) for instructions on how to build a bootable image that includes the gadget snap.
+See [Architectures](https://snapcraft.io/docs/architectures) for more details on defining architectures and [Image building](https://documentation.ubuntu.com/core/how-to-guides/image-creation/board-enablement/#image-building) for instructions on how to build a bootable image that includes the gadget snap.

--- a/docs/how-to-guides/image-creation/build-a-kernel-snap.md
+++ b/docs/how-to-guides/image-creation/build-a-kernel-snap.md
@@ -147,7 +147,7 @@ with or patching the code to add new features or test fixes.
 
 Additionally, building your own initrd as part of this process
 enables you to introduce even more complex feature support, such
-as leveraging [OP-TEE for Full Disk Encryption on non-x86_64 platforms](https://documentation.ubuntu.com/core/explanation/full-disk-encryption-op-tee/).
+as leveraging {ref}`OP-TEE for Full Disk Encryption on non-x86_64 platforms <ref-explanation-full-disk-encryption>`.
 
 For instance the below two parts within a kernel snap's `snapcraft.yaml` will
 build an entirely different kernel from the standard Canonical ones, trimming

--- a/docs/how-to-guides/image-creation/build-a-kernel-snap.md
+++ b/docs/how-to-guides/image-creation/build-a-kernel-snap.md
@@ -205,7 +205,7 @@ repackaging to end up with a kernel snap for your hardware platform!
 ## Build the snap
 
 The build system must support [snapd](https://snapcraft.io/docs/installing-snapd),
-and have both the [Snapcraft](https://documentation.ubuntu.com/snapcraft/stable/how-to/setup/set-up-snapcraft/)
+and have both the [Snapcraft](https://documentation.ubuntu.com/snapcraft/stable/how-to/set-up-snapcraft/)
 build tool and the [LXD](https://canonical.com/lxd) virtualisation platform
 installed, all of which are provided by any Ubuntu release.
 

--- a/docs/how-to-guides/image-creation/build-a-kernel-snap.md
+++ b/docs/how-to-guides/image-creation/build-a-kernel-snap.md
@@ -69,8 +69,8 @@ releases as branches.
 
 ### Crafting the snap
 
-Snapcraft provides [kernel](https://documentation.ubuntu.com/snapcraft/stable/common/craft-parts/reference/plugins/kernel_plugin/)
-and [initrd](https://documentation.ubuntu.com/snapcraft/stable/common/craft-parts/reference/plugins/initrd_plugin/)
+Snapcraft provides [kernel](https://documentation.ubuntu.com/snapcraft/latest/reference/plugins/kernel_plugin/)
+and [initrd](https://documentation.ubuntu.com/snapcraft/latest/reference/plugins/initrd_plugin/)
 plugins for creating kernel snaps. Refer to their documentation to understand
 the available options and features.
 

--- a/docs/how-to-guides/image-creation/calculate-partition-sizes.md
+++ b/docs/how-to-guides/image-creation/calculate-partition-sizes.md
@@ -28,7 +28,7 @@ The recommended sizes for each partition type and role are as follows:
 
 * _system-boot_: This partition contains the kernel image files (kernel.efi / kernel.img) for each kernel revision in the system. In addition, this partition requires the space for an additional kernel that is temporarily stored when refreshing the kernel snap.
 
-  For example, the size of kernel.efi is around 52 MiBs. If we take a [refresh.retain=3](https://snapcraft.io/docs/managing-updates#control-updates-with-system-options-5) (the default for Ubuntu Core, and for classic/hybrid it is 2) and 10 MiBs for additional boot components, such as grub and u-boot, this would give a minimum size of around:
+  For example, the size of kernel.efi is around 52 MiBs. If we take a [refresh.retain=3](https://snapcraft.io/docs/how-to-guides/manage-snaps/manage-updates/#refresh-retain) (the default for Ubuntu Core, and for classic/hybrid it is 2) and 10 MiBs for additional boot components, such as grub and u-boot, this would give a minimum size of around:
 
   52*4 + 10 = 218 MiBs
 

--- a/docs/how-to-guides/manage-ubuntu-core/create-a-recovery-system-from-the-api.md
+++ b/docs/how-to-guides/manage-ubuntu-core/create-a-recovery-system-from-the-api.md
@@ -11,7 +11,7 @@ An {ref}`Ubuntu Core image <ref-index-build-your-first-image>` contains a recove
 
 One issue with this approach is that there may be snaps included in the recovery system that have since received security updates. This will have been updated automatically in the running system, but not in the image-based recovery system. 
 
-To resolve this, the recovery system [snapd REST API](https://snapcraft.io/docs/snapd-api#heading--systems-get) enables users to create new recovery systems with snaps that are constrained by a set of {ref}`validation-sets assertions <reference-assertions-validation-set>`.
+To resolve this, the recovery system [snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/OpenAccess/getSystems) enables users to create new recovery systems with snaps that are constrained by a set of {ref}`validation-sets assertions <reference-assertions-validation-set>`.
 
 This is specifically useful for ensuring that a recovery system is built from a set of snaps with well known revisions.
 

--- a/docs/how-to-guides/manage-ubuntu-core/create-a-recovery-system-from-the-api.md
+++ b/docs/how-to-guides/manage-ubuntu-core/create-a-recovery-system-from-the-api.md
@@ -11,7 +11,7 @@ An {ref}`Ubuntu Core image <ref-index-build-your-first-image>` contains a recove
 
 One issue with this approach is that there may be snaps included in the recovery system that have since received security updates. This will have been updated automatically in the running system, but not in the image-based recovery system. 
 
-To resolve this, the recovery system [snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/OpenAccess/getSystems) enables users to create new recovery systems with snaps that are constrained by a set of {ref}`validation-sets assertions <reference-assertions-validation-set>`.
+To resolve this, the recovery system [snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/AuthenticationRequired/performSystemAction) enables users to create new recovery systems with snaps that are constrained by a set of {ref}`validation-sets assertions <reference-assertions-validation-set>`.
 
 This is specifically useful for ensuring that a recovery system is built from a set of snaps with well known revisions.
 

--- a/docs/how-to-guides/manage-ubuntu-core/modify-kernel-options.md
+++ b/docs/how-to-guides/manage-ubuntu-core/modify-kernel-options.md
@@ -25,14 +25,14 @@ In addition to parameters supported by the kernel, there are also *Ubuntu Core-s
 
 There are two [system options](https://snapcraft.io/docs/system-options) that can be used to add new kernel boot parameters to a system that has been deployed and is running:
 
-1. [system.kernel.cmdline-append](https://snapcraft.io/docs/system-options#heading--kernel-cmdline-append)
-1. [system.kernel.dangerous-cmdline-append](https://snapcraft.io/docs/system-options#heading--kernel-dangerous-cmdline-append)
+1. [system.kernel.cmdline-append](https://snapcraft.io/docs/reference/administration/system-options/#system-system-kernel-cmdline-append)
+1. [system.kernel.dangerous-cmdline-append](https://snapcraft.io/docs/reference/administration/system-options/#system-system-kernel-dangerous-cmdline-append)
 
-The first setting will permit **only** boot parameters verified against an _allow list_ in the gadget snap. See [gadget.yaml](https://snapcraft.io/docs/the-gadget-snap#heading--gadget) for further details.
+The first setting will permit **only** boot parameters verified against an _allow list_ in the gadget snap. See [gadget.yaml](https://snapcraft.io/docs/reference/development/yaml-schemas/the-gadget-snap/#dynamic-kernel-parameters) for further details.
 
 The second option is valid only for dangerous grade [models](https://ubuntu.com/core/docs/reference/assertions/model) and permits any parameter to be added.
 
-System options can be set either through the [snapd API](https://snapcraft.io/docs/snapd-api#heading--snaps-name-conf), or with the `snap set` command:
+System options can be set either through the [snapd API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/Asynchronous/setSnapConfig), or with the `snap set` command:
 
 ```bash
 snap set system system.kernel.dangerous-cmdline-append="core.bootchart"
@@ -69,7 +69,7 @@ Below we describe how to add additional static parameters (static with the meani
 
 ### Adding static parameters from the gadget
 
-The recommended way to add static parameters is by using the `kernel-cmdline` stanza as described in [gadget.yaml](https://snapcraft.io/docs/the-gadget-snap#heading--gadget). This allows to add new parameters by using the `append` list or removing some of the default Ubuntu Core parameters by putting them in the `remove` list. As already explained, a list of the allowed dynamic parameters can be set from there too.
+The recommended way to add static parameters is by using the `kernel-cmdline` stanza as described in [gadget.yaml](https://snapcraft.io/docs/reference/development/yaml-schemas/the-gadget-snap/#static-kernel-parameters). This allows to add new parameters by using the `append` list or removing some of the default Ubuntu Core parameters by putting them in the `remove` list. As already explained, a list of the allowed dynamic parameters can be set from there too.
 
 ### Files for modification
 

--- a/docs/how-to-guides/manage-ubuntu-core/modify-kernel-options.md
+++ b/docs/how-to-guides/manage-ubuntu-core/modify-kernel-options.md
@@ -30,7 +30,7 @@ There are two [system options](https://snapcraft.io/docs/system-options) that ca
 
 The first setting will permit **only** boot parameters verified against an _allow list_ in the gadget snap. See [gadget.yaml](https://snapcraft.io/docs/reference/development/yaml-schemas/the-gadget-snap/#dynamic-kernel-parameters) for further details.
 
-The second option is valid only for dangerous grade [models](https://ubuntu.com/core/docs/reference/assertions/model) and permits any parameter to be added.
+The second option is valid only for dangerous grade {ref}`models <reference-assertions-model>` and permits any parameter to be added.
 
 System options can be set either through the [snapd API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/Asynchronous/setSnapConfig), or with the `snap set` command:
 

--- a/docs/how-to-guides/manage-ubuntu-core/set-system-options.md
+++ b/docs/how-to-guides/manage-ubuntu-core/set-system-options.md
@@ -66,4 +66,4 @@ $ snap get -d system
 }
 ```
 
-See [Gadget snaps](https://snapcraft.io/docs/gadget-snap#heading--gadget) for details on how to create a default set of configuration values for a device.
+See [Gadget snaps](https://snapcraft.io/docs/reference/development/yaml-schemas/the-gadget-snap/#the-gadget-yaml-file) for details on how to create a default set of configuration values for a device.

--- a/docs/how-to-guides/manage-ubuntu-core/set-system-time.md
+++ b/docs/how-to-guides/manage-ubuntu-core/set-system-time.md
@@ -60,7 +60,7 @@ System clock synchronized: yes
 
 ## Setting a timezone
 
-The timezone can be configured with the [system.timezone](https://snapcraft.io/docs/system-options#heading--timezone) system value:
+The timezone can be configured with the [system.timezone](https://snapcraft.io/docs/reference/administration/system-options/#system-system-timezone) system value:
 
 ```
 $ snap set system system.timezone="America/Chicago"

--- a/docs/how-to-guides/manage-ubuntu-core/troubleshooting.md
+++ b/docs/how-to-guides/manage-ubuntu-core/troubleshooting.md
@@ -58,7 +58,7 @@ During a {ref}`snap refresh <explanation-refresh-control>`, _console-conf_ may d
 
 Despite the _no-ip_ message, you should still be able to connect to the device using SSH if you actually know the IP.
 
-The [snap changes](https://snapcraft.io/docs/keeping-snaps-up-to-date#heading--changes) command will show that one or more snaps are being updated and the device may need to reboot.
+The [snap changes](https://snapcraft.io/docs/how-to-guides/manage-snaps/manage-updates/#monitor-changes) command will show that one or more snaps are being updated and the device may need to reboot.
 
 The solution to the _no-ip_ error is to simply wait for any updates to complete.
 

--- a/docs/how-to-guides/manage-ubuntu-core/upgrade-ubuntu-core.md
+++ b/docs/how-to-guides/manage-ubuntu-core/upgrade-ubuntu-core.md
@@ -48,7 +48,7 @@ BUG_REPORT_URL="https://bugs.launchpad.net/snappy/"
 
 The model assertion defines which {ref}`system snaps <ref-inside-ubuntu-core_ubuntu-core-snaps>` make up the device's operating system, including the gadget snap, kernel snap and the base snap with the (read-only) root filesystem.
 
-On an Ubuntu Core 20 system, _kernel_ and _gadget_ snaps are installed from a `20` [track](https://snapcraft.io/docs/channels#heading--tracks), with the [base snap](https://snapcraft.io/docs/base-snaps) being `core20`. The _snapd_ snap remains unchanged, as it's always at the latest version available.
+On an Ubuntu Core 20 system, _kernel_ and _gadget_ snaps are installed from a `20` [track](https://snapcraft.io/docs/explanation/how-snaps-work/channels-and-tracks/#tracks), with the [base snap](https://snapcraft.io/docs/base-snaps) being `core20`. The _snapd_ snap remains unchanged, as it's always at the latest version available.
 
 The following is a complete unsigned reference model for an amd64 Ubuntu Core 20 image:
 

--- a/docs/how-to-guides/manage-ubuntu-core/use-a-recovery-mode.md
+++ b/docs/how-to-guides/manage-ubuntu-core/use-a-recovery-mode.md
@@ -15,7 +15,7 @@ These recovery modes can be accessed in three different ways:
 Start or reboot the device with the ‘1’ key held on a connected keyboard
 - **{ref}`Snap reboot <ref-use-a-recovery-mode_recovery-modes-from-snap-reboot>`**</br>
 Run `snap reboot` on the device with either `--recover` or `--install` arguments.
-- **[Snapd REST API](https://snapcraft.io/docs/snapd-api#heading--systems-get)**</br>
+- **[Snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/OpenAccess/getSystems)**</br>
 Use the REST API to call either the `recover`, `install`, `factory-reset` or `reboot` functions.
 
 Recovery modes are available on Ubuntu Core 20 and later.

--- a/docs/how-to-guides/manage-ubuntu-core/use-a-recovery-mode.md
+++ b/docs/how-to-guides/manage-ubuntu-core/use-a-recovery-mode.md
@@ -15,7 +15,7 @@ These recovery modes can be accessed in three different ways:
 Start or reboot the device with the ‘1’ key held on a connected keyboard
 - **{ref}`Snap reboot <ref-use-a-recovery-mode_recovery-modes-from-snap-reboot>`**</br>
 Run `snap reboot` on the device with either `--recover` or `--install` arguments.
-- **[Snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/OpenAccess/getSystems)**</br>
+- **[Snapd REST API](https://snapcraft.io/docs/reference/development/snapd-rest-api/#/AuthenticationRequired/performSystemAction)**</br>
 Use the REST API to call either the `recover`, `install`, `factory-reset` or `reboot` functions.
 
 Recovery modes are available on Ubuntu Core 20 and later.

--- a/docs/how-to-guides/using-ubuntu-core.md
+++ b/docs/how-to-guides/using-ubuntu-core.md
@@ -55,7 +55,7 @@ opengl                    wpe-webkit-mir-kiosk:opengl           :opengl         
 wayland                   wpe-webkit-mir-kiosk:wayland          ubuntu-frame:wayland         -
 ```
 
-Each line in the above output describes how an [interface](https://snapcraft.io/docs/supported-interfaces) is used to connect an application to a system resource. This is accomplished through a system of [plugs and slots](https://snapcraft.io/docs/interface-management#heading--slots-plugs) which connect a consumer (plug) to a provider (slot). The [network](https://snapcraft.io/docs/network-interface) interface, for example, connects the system network provider slot (`:network`) to the application consumer plug (`wpe-webkit-mir-kiosk:network`) to provide the web view with network access.
+Each line in the above output describes how an [interface](https://snapcraft.io/docs/supported-interfaces) is used to connect an application to a system resource. This is accomplished through a system of [plugs and slots](https://snapcraft.io/docs/how-to-guides/manage-snaps/connect-interfaces/#plugs-and-slots) which connect a consumer (plug) to a provider (slot). The [network](https://snapcraft.io/docs/network-interface) interface, for example, connects the system network provider slot (`:network`) to the application consumer plug (`wpe-webkit-mir-kiosk:network`) to provide the web view with network access.
 
 The `snap connect` and `snap disconnect` commands are used to remove and activate an interface connection. To disable and then re-enable network access to `wpe-webkit-mir-kiosk`, for instance, you'd type:
 

--- a/docs/how-to-guides/using-ubuntu-core.md
+++ b/docs/how-to-guides/using-ubuntu-core.md
@@ -9,7 +9,7 @@ myst:
 
 Ubuntu Core and its applications run within a confined and transaction-based environment. This provides the robustness and security that makes Ubuntu Core ideal for embedded device deployment, but it also requires a different approach from classic Ubuntu systems. 
 
-Application management, system configuration and update schedules in Ubuntu Core are managed by *snapd*, the snap packaging daemon. Snap features are explained comprehensively in the [Snap documentation](https://snapcraft.io/docs), while our [Ubuntu Core documentation](https://ubuntu.com/core/docs) handles the elements of the _snap_ ecosystem that are specifically applicable to Ubuntu Core.
+Application management, system configuration and update schedules in Ubuntu Core are managed by *snapd*, the snap packaging daemon. Snap features are explained comprehensively in the [Snap documentation](https://snapcraft.io/docs), while our {ref}`Ubuntu Core documentation <ref-index_ubuntu-core-documentation>` handles the elements of the _snap_ ecosystem that are specifically applicable to Ubuntu Core.
 
 ```{admonition} Create your own images
 :class: tip

--- a/docs/reference/assertions/index.md
+++ b/docs/reference/assertions/index.md
@@ -9,7 +9,7 @@ myst:
 
 An assertion is a digitally signed document that either verifies the validity of a process, as attested by the signer, or carries policy information, as formulated by the signer.
 
-[Snapcraft](https://snapcraft.io/docs/snapcraft), [snapd](https://snapcraft.io/docs/glossary#heading--snapd), the [Snap Store](https://snapcraft.io/store) and {ref}`Brand stores <ref-dedicated-snap-store_dedicated-snap-store>` all use assertions to handle a variety of functions and processes, including authentication, policy setting, identification and validation.
+[Snapcraft](https://snapcraft.io/docs/snapcraft), [snapd](https://snapcraft.io/docs/reference/glossary/#snapd), the [Snap Store](https://snapcraft.io/store) and {ref}`Brand stores <ref-dedicated-snap-store_dedicated-snap-store>` all use assertions to handle a variety of functions and processes, including authentication, policy setting, identification and validation.
 
 Assertions are text-based and take a context-dependent format that always includes one or more headers, an optional body, and the encoded signature.
 

--- a/docs/reference/assertions/snap-revision.md
+++ b/docs/reference/assertions/snap-revision.md
@@ -7,7 +7,7 @@ myst:
 (reference-assertions-snap-revision)=
 # snap-revision
 
-The _snap-revision_ {ref}`assertion <ref-index_assertions>` is a statement by the {ref}`store <explanation-stores-store-overview>` acknowledging the receipt of a snap build and labelling it with a snap [revision](https://snapcraft.io/docs/glossary#heading--revision). 
+The _snap-revision_ {ref}`assertion <ref-index_assertions>` is a statement by the {ref}`store <explanation-stores-store-overview>` acknowledging the receipt of a snap build and labelling it with a snap [revision](https://snapcraft.io/docs/reference/glossary/#revision).
 
 Alongside {ref}`account <reference-assertions-account>`, {ref}`snap-declaration <reference-assertions-snap-declaration>` and {ref}`account-key-assertion <reference-assertions-account-key>` assertions,  snap-revision_ is bundled within the composite `.assert` file that accompanies a snap downloaded with the `snap download <snap-name>` command.
 

--- a/docs/reference/assertions/validation.md
+++ b/docs/reference/assertions/validation.md
@@ -7,7 +7,7 @@ myst:
 (reference-assertions-validation)=
 # validation
 
-The _validation_ {ref}`assertion <ref-index_assertions>`  declares that a certain [revision](https://snapcraft.io/docs/glossary#heading--revision) for a _snap that is gated by another snap_ has been validated for a given [series](https://snapcraft.io/docs/glossary#heading--series). It is closely related to the {ref}`snap-declaration <reference-assertions-snap-declaration>` assertion.
+The _validation_ {ref}`assertion <ref-index_assertions>`  declares that a certain [revision](https://snapcraft.io/docs/reference/glossary/#revision) for a _snap that is gated by another snap_ has been validated for a given [series](https://snapcraft.io/docs/reference/glossary/#series). It is closely related to the {ref}`snap-declaration <reference-assertions-snap-declaration>` assertion.
 
 ## Validation assertion fields
 

--- a/docs/reference/gadget-snap-format.md
+++ b/docs/reference/gadget-snap-format.md
@@ -48,8 +48,8 @@ In addition to the above, the IoT Devices Field team maintains a GitHub reposito
 - [arm64-orange-pi-5plus](https://github.com/canonical/iot-field-gadget-snap/tree/22/orangepi-5plus)
 - [amd64-pc](https://github.com/canonical/iot-field-gadget-snap/tree/22/pc)
 - [amd64-pc-classic](https://github.com/canonical/iot-field-gadget-snap/tree/22/pc-classic)
-- [risc64-icicle](https://github.com/canonical/iot-field-gadget-snap/tree/22/polarfire-icicle)
-- [risc64-nezha](https://github.com/canonical/iot-field-gadget-snap/tree/24/nezha)
+- [riscv64-icicle](https://github.com/canonical/iot-field-gadget-snap/tree/22/polarfire-icicle)
+- [riscv64-nezha](https://github.com/canonical/iot-field-gadget-snap/tree/24/nezha)
 
 In the near future, we expect to add a RISC-V reference gadget snap to this list.
 

--- a/docs/reference/gadget-snap-format.md
+++ b/docs/reference/gadget-snap-format.md
@@ -194,7 +194,7 @@ The parameters from `append` will be added to the default command line. The para
 
 The `meta/gadget.yaml` file contains the basic metadata for gadget-specific functionality, including a detailed specification of which structure items compose an image. The latter is used both by snapd and by ubuntu-image when creating images for these devices.
 
-A gadget snap's boot assets can also be automatically updated when the snap is refreshed. See [Updating gadget boot assets](https://snapcraft.io/docs/gadget-boot-assets) for further details.
+A gadget snap's boot assets can also be automatically updated when the snap is refreshed. See {ref}`Updating gadget boot assets <interfaces-gadget-boot-assets>` for further details.
 
 The following specification defines what is supported in `gadget.yaml`:
 

--- a/docs/reference/gadget-snap-format.md
+++ b/docs/reference/gadget-snap-format.md
@@ -43,12 +43,12 @@ For U-Boot devices example gadgets can be found in:
 
 In addition to the above, the IoT Devices Field team maintains a GitHub repository with source code branches that contain templates for the following device architectures:
 
-- [arm64-odroid-hc4](https://github.com/canonical/iot-field-gadget-snap/tree/22-arm64-odroid-hc4)
-- [arm64-orange-pi-5plus](https://github.com/canonical/iot-field-gadget-snap/tree/22-arm64-orange-pi-5plus)
-- [amd64-pc](https://github.com/canonical/iot-field-gadget-snap/tree/22-amd64-pc)
-- [amd64-pc-classic](https://github.com/canonical/iot-field-gadget-snap/tree/22-amd64-pc-classic)
-- [risc64-icicle](https://github.com/canonical/iot-field-gadget-snap/tree/22-riscv64-icicle)
-- [risc64-nezha](https://github.com/canonical/iot-field-gadget-snap/tree/24-riscv64-nezha)
+- [arm64-odroid-hc4](https://github.com/canonical/iot-field-gadget-snap/tree/22/odroid-hc4)
+- [arm64-orange-pi-5plus](https://github.com/canonical/iot-field-gadget-snap/tree/22/orangepi-5plus)
+- [amd64-pc](https://github.com/canonical/iot-field-gadget-snap/tree/22/pc)
+- [amd64-pc-classic](https://github.com/canonical/iot-field-gadget-snap/tree/22/pc-classic)
+- [risc64-icicle](https://github.com/canonical/iot-field-gadget-snap/tree/22/polarfire-icicle)
+- [risc64-nezha](https://github.com/canonical/iot-field-gadget-snap/tree/24/nezha)
 
 In the near future, we expect to add a RISC-V reference gadget snap to this list.
 

--- a/docs/reference/gadget-snap-format.md
+++ b/docs/reference/gadget-snap-format.md
@@ -29,6 +29,7 @@ In addition to traditional snap metadata, the gadget snap also holds some setup 
 - **uboot.conf**: marker file that declares that the gadget needs the U-Boot bootloader and that files in the seed and boot partitions are used to store U-Boot environment. (Note: this is not needed when using a system-boot-state partition.)
 - **cloud.conf**: optional [cloud-init](https://cloudinit.readthedocs.io/en/latest/) configuration; cloud-init is disabled if missing. </br>Using cloud-init is _not recommended_ for production devices, and should only be included for testing and development purposes.
 
+(reference-gadget-snap-format-example-gadget-snaps)=
 ## Example gadget snaps
 
 The following gadget repositories contain the gadget snap definitions for _amd64_ (64 bit PC Gadget Snap) and the Raspberry Pi family of devices supported by Ubuntu Core:

--- a/docs/reference/gadget-snap-format.md
+++ b/docs/reference/gadget-snap-format.md
@@ -17,7 +17,7 @@ The gadget metadata and content defines:
 -   Interface connections configured in the `connections:` section are executed on the device’s first boot only. Later changes to this section -- that is, changes added to the device at run time through gadget refreshes -- are not applied.
 -   Optional hooks that are invoked to control and customize the behavior over the device lifecycle, e.g. installation, initialisation and establishing device identity, factory reset.
 
-See {ref}`Building a gadget snap <how-to-guides-image-creation-build-a-gadget-snap>` for details on how a gadget snap can be built. For store deployment, gadget snaps must be produced by the device [brand](https://snapcraft.io/docs/glossary#heading--brand-store), as defined in the {ref}`model assertion <reference-assertions-model>`, or a reference gadget must be used. It is perfectly possible for different models to share a gadget snap.
+See {ref}`Building a gadget snap <how-to-guides-image-creation-build-a-gadget-snap>` for details on how a gadget snap can be built. For store deployment, gadget snaps must be produced by the device [brand](https://snapcraft.io/docs/reference/glossary/#brand-store), as defined in the {ref}`model assertion <reference-assertions-model>`, or a reference gadget must be used. It is perfectly possible for different models to share a gadget snap.
 
 ## Setup files
 
@@ -153,8 +153,8 @@ Volumes using `schema: emmc` use the same `volume-assignments` syntax (see above
 
 There are two [system options](https://snapcraft.io/docs/system-options) that can be used to add new kernel boot parameters to a system that has been deployed and is running:
 
-1. [system.kernel.cmdline-append](https://snapcraft.io/docs/system-options#heading--kernel-cmdline-append)
-2. [system.kernel.dangerous-cmdline-append](https://snapcraft.io/docs/system-options#heading--kernel-dangerous-cmdline-append)
+1. [system.kernel.cmdline-append](https://snapcraft.io/docs/reference/administration/system-options/#system-system-kernel-cmdline-append)
+2. [system.kernel.dangerous-cmdline-append](https://snapcraft.io/docs/reference/administration/system-options/#system-system-kernel-dangerous-cmdline-append)
 
 The second setting can be run (dangerously) without any prior configuration, but the first setting will permit **only** boot parameters verified against an *allow list* defined within the gadget snap.
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -128,7 +128,7 @@ New features for this release include:
 - New ROS integration for robotics developers
 - New documentation and documentation structure
 
-In addition to the above, Ubuntu Core 24 bundles both the latest Linux Kernel  6.8 and *systemd* 2.55 and includes all the latest features of _snapd_, including {ref}`Dynamic kernel boot parameters <how-to-guides-manage-ubuntu-core-modify-kernel-options>`, [Quota group limits for Journal log](https://snapcraft.io/docs/quota-groups#heading--journal) and {ref}`Offline remodeling <ref-remodelling_offline-remodeling>`.
+In addition to the above, Ubuntu Core 24 bundles both the latest Linux Kernel  6.8 and *systemd* 2.55 and includes all the latest features of _snapd_, including {ref}`Dynamic kernel boot parameters <how-to-guides-manage-ubuntu-core-modify-kernel-options>`, [Quota group limits for Journal log](https://snapcraft.io/docs/how-to-guides/manage-snaps/use-resource-quotas/#journal-log-limits) and {ref}`Offline remodeling <ref-remodelling_offline-remodeling>`.
 
 Support for Ubuntu Core has also been added to {ref}`Multipass <tutorials-get-started-try-pre-built-images-install-on-a-vm>`, for single-command deployment.
 
@@ -162,7 +162,7 @@ These snaps enable organisations to deploy, manage, and monitor OCI edge workloa
 
 Core 24 delivers production-ready integrations for developers deploying solutions with the Robot Operating System (ROS).
 
-Canonical has made [ROS foundational snaps](https://snapcraft.io/docs/ros2-applications#heading--content-sharing) available for modular deployments. These snaps are maintained by Canonical, and include sets of common ROS packages, such as ros_core, ros_base or desktop, available in several flavours per ROS distribution. With them, developers can design modular ROS snap deployments, enabling configurability and reducing overall memory and OTA update bandwidth.
+Canonical has made [ROS foundational snaps](https://documentation.ubuntu.com/snapcraft/stable/how-to/integrations/craft-an-ros-2-app/#share-content-between-ros-2-snaps) available for modular deployments. These snaps are maintained by Canonical, and include sets of common ROS packages, such as ros_core, ros_base or desktop, available in several flavours per ROS distribution. With them, developers can design modular ROS snap deployments, enabling configurability and reducing overall memory and OTA update bandwidth.
 
 ### New documentation and documentation structure
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -45,7 +45,7 @@ Other [risks levels](https://snapcraft.io/docs/channels) are available for testi
 
 ## Update mechanisms in Ubuntu Core
 
-When Ubuntu Core is running, its snap packages update (aka refresh) automatically. To manually control or modify this process, see {ref}`Refresh control <explanation-refresh-control>`. Essential snaps, such as the base and kernel snaps, can be refreshed assuming the updated version is built from the same build-base used in the original model definition. When refreshing the base or kernel snaps, the system will automatically reboot to apply the freshly installed snap. When refreshing the gadget snap, a reboot occurs if the [boot-assets](https://snapcraft.io/docs/gadget-boot-assets) are modified.
+When Ubuntu Core is running, its snap packages update (aka refresh) automatically. To manually control or modify this process, see {ref}`Refresh control <explanation-refresh-control>`. Essential snaps, such as the base and kernel snaps, can be refreshed assuming the updated version is built from the same build-base used in the original model definition. When refreshing the base or kernel snaps, the system will automatically reboot to apply the freshly installed snap. When refreshing the gadget snap, a reboot occurs if the {ref}`boot assets <interfaces-gadget-boot-assets>` are modified.
 
 To upgrade an Ubuntu Core image from one version to another, see {ref}`Upgrade Ubuntu Core <how-to-guides-manage-ubuntu-core-upgrade-ubuntu-core>`. This process is known as {ref}`remodeling <explanation-remodeling>`.
 

--- a/docs/tutorials/try-pre-built-images/install-on-a-vm.md
+++ b/docs/tutorials/try-pre-built-images/install-on-a-vm.md
@@ -181,7 +181,7 @@ This example turns a pre-built Ubuntu Core image into a network-accessible AI in
 > **Note:**
 > In a final product, snaps such as `gemma4` would normally be included and configured in your custom Ubuntu Core image, rather than installed manually after first boot. With this approach, the device or VM starts directly into the experience you have configured. End users do not need to see these setup instructions, interact with the Ubuntu Core login message, or log in to the Core instance unless your product design requires it. You control the product experience you choose to deliver.
 >
-> A custom Ubuntu Core image is described with a [model assertion](https://documentation.ubuntu.com/core/reference/assertions/model/), which defines the snaps that make up the device image, including required or optional application snaps.
+> A custom Ubuntu Core image is described with a {ref}`model assertion <reference-assertions-model>`, which defines the snaps that make up the device image, including required or optional application snaps.
 >
 > Alternatively, snaps can be installed, configured and managed later through a fleet management process. [Landscape](https://documentation.ubuntu.com/landscape/) provides centralised administration for Ubuntu deployments, including IoT devices.
 


### PR DESCRIPTION
Fix links, tags, redirects, and other identified issues.

Related: https://github.com/canonical/snap-docs/pull/526

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-37370